### PR TITLE
Switching TemplateData to interface{} Values

### DIFF
--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -51,7 +51,7 @@ func (e *Emailer) SendEmail(req *SendEmailRequest) error {
 }
 
 // TemplateData represents the key-value data for the template
-type TemplateData map[string]string
+type TemplateData map[string]interface{}
 
 // SendTemplateEmailRequest provides all the parameters to SendTemplateEmail to
 // deliver an templated email.

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -11,8 +11,16 @@ import (
 // NewEmailer is a convenience function that returns a new Emailer struct with
 // the given apiKey
 func NewEmailer(apiKey string) *Emailer {
+	return NewEmailerWithSandbox(apiKey, false)
+}
+
+// NewEmailerWithSandbox is a convenience function that returns a new Emailer struct with
+// the given apiKey for use with the Sendgrid sandbox.
+// FOR TESTING PURPOSES, use NewEmailer for production code.
+func NewEmailerWithSandbox(apiKey string, useSandbox bool) *Emailer {
 	return &Emailer{
 		sendGridClient: sendgrid.NewSendClient(apiKey),
+		useSandbox:     useSandbox,
 	}
 }
 
@@ -20,6 +28,7 @@ func NewEmailer(apiKey string) *Emailer {
 // easier to use.
 type Emailer struct {
 	sendGridClient *sendgrid.Client
+	useSandbox     bool
 }
 
 // SendEmailRequest provides all the parameters to SendEmail to deliver an email.
@@ -38,12 +47,18 @@ func (e *Emailer) SendEmail(req *SendEmailRequest) error {
 	from := mail.NewEmail(req.FromName, req.FromEmail)
 	to := mail.NewEmail(req.ToName, req.ToEmail)
 	msg := mail.NewSingleEmail(from, req.Subject, to, req.Text, req.HTML)
+	msg.MailSettings = &mail.MailSettings{
+		SandboxMode: &mail.Setting{
+			Enable: &e.useSandbox,
+		},
+	}
 
 	resp, err := e.sendGridClient.Send(msg)
 	if err != nil {
 		log.Errorf("Error sending email: err: %v", err)
 		return err
 	}
+	log.Infof("sendemail: useSandbox: %v", e.useSandbox)
 	log.Infof("sendemail: response status: %v", resp.StatusCode)
 	log.Infof("sendemail: response body: %v", resp.Body)
 	log.Infof("sendemail: response headers: %v", resp.Headers)
@@ -68,6 +83,11 @@ type SendTemplateEmailRequest struct {
 // SendTemplateEmail sends an email based on a template in the email provider.
 func (e *Emailer) SendTemplateEmail(req *SendTemplateEmailRequest) error {
 	msg := mail.NewV3Mail()
+	msg.MailSettings = &mail.MailSettings{
+		SandboxMode: &mail.Setting{
+			Enable: &e.useSandbox,
+		},
+	}
 
 	from := mail.NewEmail(req.FromName, req.FromEmail)
 	to := mail.NewEmail(req.ToName, req.ToEmail)
@@ -95,6 +115,7 @@ func (e *Emailer) SendTemplateEmail(req *SendTemplateEmailRequest) error {
 		log.Errorf("Error sending email: err: %v", err)
 		return err
 	}
+	log.Infof("sendemail: useSandbox: %v", e.useSandbox)
 	log.Infof("sendemail: response status: %v", resp.StatusCode)
 	log.Infof("sendemail: response body: %v", resp.Body)
 	log.Infof("sendemail: response headers: %v", resp.Headers)

--- a/pkg/email/email_test.go
+++ b/pkg/email/email_test.go
@@ -4,7 +4,7 @@ package email_test
 
 import (
 	"testing"
-	// "github.com/joincivil/civil-api-server/pkg/utils"
+	// "github.com/joincivil/go-common/pkg/email"
 )
 
 // const (
@@ -30,14 +30,14 @@ func TestSimpleEmailSend(t *testing.T) {
 }
 
 func TestTemplateEmailSend(t *testing.T) {
-	// emailer := utils.NewEmailer(sendGridEmailKey)
+	// emailer := email.NewEmailer(sendGridEmailKey)
 
-	// templateData := utils.TemplateData{}
+	// templateData := email.TemplateData{}
 	// templateData["name"] = "Peter Ng"
 	// templateData["subject"] = "Testing Emailer with Template"
 	// templateData["preheader"] = "Preheader Test"
 
-	// req := &utils.SendTemplateEmailRequest{
+	// req := &email.SendTemplateEmailRequest{
 	// 	ToName:       "Peter Ng",
 	// 	ToEmail:      "peter@civil.co",
 	// 	FromName:     "The Civil Media Company",

--- a/pkg/email/email_test.go
+++ b/pkg/email/email_test.go
@@ -2,51 +2,74 @@
 
 package email_test
 
+// To test this, add SENDGRID_TEST_KEY=<sendgrid key> to your environment before
+// running, or add that var inline to your test command.
+
 import (
+	"os"
 	"testing"
-	// "github.com/joincivil/go-common/pkg/email"
+
+	"github.com/joincivil/go-common/pkg/email"
 )
 
-// const (
-// 	sendGridEmailKey = ""
-// )
+const (
+	sendGridKeyEnvVar = "SENDGRID_TEST_KEY"
+
+	useSandbox = true
+)
+
+func getSendGridKeyFromEnvVar() string {
+	return os.Getenv(sendGridKeyEnvVar)
+}
 
 func TestSimpleEmailSend(t *testing.T) {
-	// emailer := utils.NewEmailer(sendGridEmailKey)
+	sendGridKey := getSendGridKeyFromEnvVar()
+	if sendGridKey == "" {
+		t.Log("No SENDGRID_TEST_KEY set, skipping sendgrid test")
+		return
+	}
 
-	// req := &utils.SendEmailRequest{
-	// 	ToName:    "Peter Ng",
-	// 	ToEmail:   "peter@civil.co",
-	// 	FromName:  "The Civil Media Company",
-	// 	FromEmail: "support@civil.co",
-	// 	Subject:   "Testing Emailer",
-	// 	Text:      "This is test text.\nThis is another line of test text.\tTabbed text",
-	// 	HTML:      "<p>This is a paragraph</p><p>This is another paragraph</p><p><b>TESTTESTSETSTSETEST!</b></p>",
-	// }
-	// err := emailer.SendEmail(req)
-	// if err != nil {
-	// 	t.Errorf("Should have sent the email: err: %v", err)
-	// }
+	emailer := email.NewEmailerWithSandbox(sendGridKey, useSandbox)
+
+	req := &email.SendEmailRequest{
+		ToName:    "Peter Ng",
+		ToEmail:   "peter@civil.co",
+		FromName:  "The Civil Media Company",
+		FromEmail: "support@civil.co",
+		Subject:   "Testing Emailer",
+		Text:      "This is test text.\nThis is another line of test text.\tTabbed text",
+		HTML:      "<p>This is a paragraph</p><p>This is another paragraph</p><p><b>TESTTESTSETSTSETEST!</b></p>",
+	}
+	err := emailer.SendEmail(req)
+	if err != nil {
+		t.Errorf("Should have sent the email: err: %v", err)
+	}
 }
 
 func TestTemplateEmailSend(t *testing.T) {
-	// emailer := email.NewEmailer(sendGridEmailKey)
+	sendGridKey := getSendGridKeyFromEnvVar()
+	if sendGridKey == "" {
+		t.Log("No SENDGRID_TEST_KEY set, skipping sendgrid test")
+		return
+	}
 
-	// templateData := email.TemplateData{}
-	// templateData["name"] = "Peter Ng"
-	// templateData["subject"] = "Testing Emailer with Template"
-	// templateData["preheader"] = "Preheader Test"
+	emailer := email.NewEmailerWithSandbox(sendGridKey, useSandbox)
 
-	// req := &email.SendTemplateEmailRequest{
-	// 	ToName:       "Peter Ng",
-	// 	ToEmail:      "peter@civil.co",
-	// 	FromName:     "The Civil Media Company",
-	// 	FromEmail:    "support@civil.co",
-	// 	TemplateID:   "d-19c58510201a4deab1ec6634632ccd11",
-	// 	TemplateData: templateData,
-	// }
-	// err := emailer.SendTemplateEmail(req)
-	// if err != nil {
-	// 	t.Errorf("Should have sent the email: err: %v", err)
-	// }
+	templateData := email.TemplateData{}
+	templateData["name"] = "Peter Ng"
+	templateData["subject"] = "Testing Emailer with Template"
+	templateData["preheader"] = "Preheader Test"
+
+	req := &email.SendTemplateEmailRequest{
+		ToName:       "Peter Ng",
+		ToEmail:      "peter@civil.co",
+		FromName:     "The Civil Media Company",
+		FromEmail:    "support@civil.co",
+		TemplateID:   "d-19c58510201a4deab1ec6634632ccd11",
+		TemplateData: templateData,
+	}
+	err := emailer.SendTemplateEmail(req)
+	if err != nil {
+		t.Errorf("Should have sent the email: err: %v", err)
+	}
 }


### PR DESCRIPTION
- Since the sendgrid dynamic template data takes `interface{}` instead of just string.  Need this to send slices and maps to the template instead of just strings.
- Some small fixes to the sendgrid tests.
- Added a flag to use the Sendgrid sandbox which allows us to enable the sendgrid tests without spamming.