### PR TITLE
CIVIL-274 - Jobs Service / Jobs / Tx Listener

### DIFF
--- a/pkg/eth/ecdsa.go
+++ b/pkg/eth/ecdsa.go
@@ -2,7 +2,8 @@ package eth
 
 import (
 	"crypto/ecdsa"
-	"log"
+
+	log "github.com/golang/glog"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/pkg/eth/service.go
+++ b/pkg/eth/service.go
@@ -1,0 +1,11 @@
+package eth
+
+// Service provides tools that help with interacting with the Ethereum blockchain
+type Service struct {
+	TxListener *TxListener
+}
+
+// NewService creates a new Service instance
+func NewService(txListener *TxListener) *Service {
+	return &Service{TxListener: txListener}
+}

--- a/pkg/eth/tx_listener.go
+++ b/pkg/eth/tx_listener.go
@@ -1,0 +1,99 @@
+package eth
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/golang/glog"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/joincivil/go-common/pkg/jobs"
+)
+
+const (
+	// TxListenerTransactionCompleteMsg is the message sent when the transaction is completed
+	TxListenerTransactionCompleteMsg = "Transaction is complete"
+
+	// TxListenerTransactionPendingMsg is the message sent when the transaction completion is
+	// pending
+	TxListenerTransactionPendingMsg = "Transaction is pending"
+
+	// TxListenerTransactionErrorMsgPrefix is the message sent when there is an error with transaction
+	// polling
+	TxListenerTransactionErrorMsgPrefix = "Error: err:"
+
+	txListenerPrefix = "TxListener"
+)
+
+// TxListener provides methods to interact with Ethereum transactions
+type TxListener struct {
+	blockchain *ethclient.Client
+	jobs       jobs.JobService
+}
+
+// NewTxListener creates a new TransactionService instance
+func NewTxListener(blockchain *ethclient.Client, jobs jobs.JobService) *TxListener {
+	return &TxListener{blockchain, jobs}
+}
+
+// StartListener begins listening for an ethereum transaction
+func (t *TxListener) StartListener(txID string) (*jobs.Subscription, error) {
+	jobID := fmt.Sprintf("%v-%v", txListenerPrefix, txID)
+	job, err := t.jobs.StartJob(jobID, func(updates chan<- string) {
+		t.PollForTxCompletion(txID, updates)
+	})
+	if err != nil && err != jobs.ErrJobAlreadyExists {
+		return nil, err
+	}
+
+	if err == jobs.ErrJobAlreadyExists {
+		job, err = t.jobs.GetJob(jobID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	subscription := job.Subscribe()
+
+	return subscription, nil
+}
+
+// StopSubscription will stop subscribing to job updates
+// this will not cancel the actual job
+func (t *TxListener) StopSubscription(receipt *jobs.Subscription) error {
+	return t.jobs.StopSubscription(receipt)
+}
+
+// PollForTxCompletion will continuously poll until a transaction is complete
+func (t *TxListener) PollForTxCompletion(txID string, updates chan<- string) {
+
+	hash := common.HexToHash(txID)
+
+	ticker := time.NewTicker(time.Millisecond * 500)
+
+	for range ticker.C {
+		isPending, err := t.checkTx(hash)
+		if err != nil {
+			updates <- fmt.Sprintf("%v %v", TxListenerTransactionErrorMsgPrefix, err.Error())
+			return
+		}
+		if !isPending {
+			updates <- TxListenerTransactionCompleteMsg
+			return
+		}
+		updates <- TxListenerTransactionPendingMsg
+	}
+
+}
+
+func (t *TxListener) checkTx(hash common.Hash) (bool, error) {
+	_, isPending, err := t.blockchain.TransactionByHash(context.Background(), hash)
+	if err != nil {
+		log.Errorf("Error retrieving transaction by hash: err: %v\n", err)
+		return false, err
+	}
+
+	return isPending, nil
+}

--- a/pkg/eth/tx_listener_test.go
+++ b/pkg/eth/tx_listener_test.go
@@ -44,6 +44,5 @@ func TestTxListener(t *testing.T) {
 
 	wg.Wait()
 	t.Log("Complete")
-	//svc.WaitForTx()
 
 }

--- a/pkg/eth/tx_listener_test.go
+++ b/pkg/eth/tx_listener_test.go
@@ -1,0 +1,49 @@
+package eth_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/joincivil/go-common/pkg/eth"
+	"github.com/joincivil/go-common/pkg/jobs"
+)
+
+func TestTxListener(t *testing.T) {
+	var wg sync.WaitGroup
+	client, err := ethclient.Dial("https://mainnet.infura.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc := eth.NewTxListener(client, jobs.NewInMemoryJobService())
+
+	sub1, err := svc.StartListener("0x3d8a78e268db358a88ae1006138d65dc06f7369617b9b991d694abbce13fe3aa")
+	if err != nil {
+		t.Fatalf("sub1: unable to get tx subscription")
+	}
+	sub2, err := svc.StartListener("0x3d8a78e268db358a88ae1006138d65dc06f7369617b9b991d694abbce13fe3aa")
+	if err != nil {
+		t.Fatalf("sub2: unable to get tx subscription")
+	}
+
+	wg.Add(2)
+	go func() {
+		for event := range sub1.Updates {
+			t.Logf("sub1: %v", event)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for event := range sub2.Updates {
+			t.Logf("sub2: %v", event)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+	t.Log("Complete")
+	//svc.WaitForTx()
+
+}

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -1,0 +1,119 @@
+package jobs
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	// ErrJobDoesNotExist is thrown when retrieving a job that does not exist
+	ErrJobDoesNotExist = errors.New("Job does not exist")
+	// ErrJobAlreadyExists is thrown when trying to submit a job with the same ID as one previously submitted
+	ErrJobAlreadyExists = errors.New("Job with this ID already exists")
+)
+
+// Subscription receives job updates
+type Subscription struct {
+	JobID        string
+	SubscriberID string
+	Updates      chan string
+}
+
+// Job is a reference to a running job
+type Job struct {
+	ID        string
+	status    string
+	observers map[string]*Subscription
+	updates   chan string
+	work      func(chan<- string)
+	mu        sync.Mutex
+}
+
+// NewJob creates a new job instance
+func NewJob(jobID string, work func(chan<- string)) *Job {
+	job := &Job{
+		ID:        jobID,
+		observers: map[string]*Subscription{},
+		work:      work,
+		updates:   make(chan string),
+		status:    "initialized",
+	}
+	return job
+}
+
+// GetStatus returns the status of the job
+func (j *Job) GetStatus() string {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.status
+}
+
+// GetStatus returns the status of the job
+func (j *Job) setStatus(status string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.status = status
+}
+
+// Start begins working on a job
+func (j *Job) Start() {
+
+	// start doing the work
+	go func() {
+		j.setStatus("running")
+		j.work(j.updates)
+		j.setStatus("complete")
+		close(j.updates)
+	}()
+
+	go func() {
+		// copy all updates to all subscribers
+		for msg := range j.updates {
+			j.mu.Lock()
+			for _, subscription := range j.observers {
+				subscription.Updates <- msg
+			}
+			j.mu.Unlock()
+		}
+		// work is complete, so close all of the observers
+		j.mu.Lock()
+		for _, observer := range j.observers {
+			close(observer.Updates)
+			delete(j.observers, observer.SubscriberID)
+		}
+		j.mu.Unlock()
+	}()
+
+}
+
+// Subscribe creates a channel that provides updates to the work
+func (j *Job) Subscribe() *Subscription {
+	id := randString(10)
+	sub := &Subscription{
+		JobID:        j.ID,
+		SubscriberID: id,
+		Updates:      make(chan string),
+	}
+
+	j.mu.Lock()
+	j.observers[id] = sub
+	j.mu.Unlock()
+	return sub
+}
+
+// Unsubscribe removes a subscription from the broadcast
+func (j *Job) Unsubscribe(receipt *Subscription) {
+	subscription := j.observers[receipt.SubscriberID]
+	close(subscription.Updates)
+	j.mu.Lock()
+	delete(j.observers, receipt.SubscriberID)
+	j.mu.Unlock()
+}
+
+// WaitForFinish subscribes to job updates and returns when the channel closes
+func (j *Job) WaitForFinish() {
+	s := j.Subscribe()
+	for range s.Updates {
+
+	}
+}

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1,0 +1,139 @@
+package jobs_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/joincivil/go-common/pkg/jobs"
+)
+
+type Spy struct {
+	RunCount int
+}
+
+func NewSpy() *Spy {
+	return &Spy{
+		RunCount: 0,
+	}
+}
+
+func (s *Spy) Run() {
+	s.RunCount = s.RunCount + 1
+}
+
+func buildJob(spy *Spy) *jobs.Job {
+	jobID := "test"
+	work := func(updates chan<- string) {
+		updates <- "foo"
+		updates <- "bar"
+		spy.Run()
+	}
+	return jobs.NewJob(jobID, work)
+}
+
+func TestJob(t *testing.T) {
+
+	t.Run("run work", func(t *testing.T) {
+		spy := NewSpy()
+		job := buildJob(spy)
+		if job.GetStatus() != "initialized" {
+			t.Fatalf("job status should be `initialized`")
+		}
+		if spy.RunCount > 0 {
+			t.Fatalf("work function should not have run")
+		}
+
+		job.Start()
+		job.WaitForFinish()
+		if job.GetStatus() != "complete" {
+			t.Fatalf("job status should be `complete`")
+		}
+		if spy.RunCount != 1 {
+			t.Fatalf("work function should be 1")
+		}
+	})
+
+	t.Run("subscriptions", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		spy := NewSpy()
+		spySub1 := NewSpy()
+		spySub2 := NewSpy()
+		job := buildJob(spy)
+		sub1 := job.Subscribe()
+		sub2 := job.Subscribe()
+		job.Start()
+
+		go func() {
+			for range sub1.Updates {
+				spySub1.Run()
+			}
+			wg.Done()
+		}()
+
+		go func() {
+			for range sub2.Updates {
+				spySub2.Run()
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+
+		if job.GetStatus() != "complete" {
+			t.Fatalf("job status should be `complete`")
+		}
+		if spy.RunCount != 1 {
+			t.Fatalf("work RunCount should be 1 but is %v", spy.RunCount)
+		}
+		if spySub1.RunCount != 2 {
+			t.Fatalf("work RunCount should be 2 but is %v", spySub1.RunCount)
+		}
+		if spySub2.RunCount != 2 {
+			t.Fatalf("work RunCount should be 2 but is %v", spySub2.RunCount)
+		}
+	})
+
+	t.Run("unsubscribe", func(t *testing.T) {
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		spyJob := NewSpy()
+		spySub1 := NewSpy()
+		spySub2 := NewSpy()
+
+		job := buildJob(spyJob)
+		sub1 := job.Subscribe()
+		sub2 := job.Subscribe()
+
+		job.Unsubscribe(sub2)
+		job.Start()
+
+		go func() {
+			for range sub1.Updates {
+				spySub1.Run()
+			}
+			wg.Done()
+		}()
+
+		go func() {
+			for range sub2.Updates {
+				spySub2.Run()
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
+
+		if spyJob.RunCount != 1 {
+			t.Fatalf("work RunCount should be 1 but is %v", spyJob.RunCount)
+		}
+		if spySub1.RunCount != 2 {
+			t.Fatalf("spySub3 RunCount should be 0 but is %v", spyJob.RunCount)
+		}
+		if spySub2.RunCount != 0 {
+			t.Fatalf("spySub3 RunCount should be 0 but is %v", spySub2.RunCount)
+		}
+
+	})
+}

--- a/pkg/jobs/service.go
+++ b/pkg/jobs/service.go
@@ -1,8 +1,9 @@
 package jobs
 
 import (
-	"log"
 	"math/rand"
+
+	log "github.com/golang/glog"
 )
 
 // JobService interface defines what is needed to retrieve and persist jobs
@@ -32,7 +33,7 @@ func (s *InMemoryJobService) StartJob(id string, work func(updates chan<- string
 		return nil, ErrJobAlreadyExists
 	}
 
-	log.Println("Starting job with ID " + id)
+	log.Infof("Starting job with ID %v", id)
 	job = NewJob(id, work)
 	s.jobs[id] = job
 
@@ -40,7 +41,7 @@ func (s *InMemoryJobService) StartJob(id string, work func(updates chan<- string
 
 	go func() {
 		job.WaitForFinish()
-		log.Printf("Job complete (%v), cleaning up", id)
+		log.Infof("Job complete (%v), cleaning up", id)
 		delete(s.jobs, id)
 	}()
 

--- a/pkg/jobs/service.go
+++ b/pkg/jobs/service.go
@@ -1,0 +1,86 @@
+package jobs
+
+import (
+	"log"
+	"math/rand"
+)
+
+// JobService interface defines what is needed to retrieve and persist jobs
+type JobService interface {
+	GetJob(id string) (*Job, error)
+	StartJob(id string, work func(updates chan<- string)) (*Job, error)
+	StopSubscription(receipt *Subscription) error
+}
+
+// InMemoryJobService is an implementation of JobService that only stays in memory
+type InMemoryJobService struct {
+	jobs map[string]*Job
+}
+
+// NewInMemoryJobService builds a new InMemoryJobService
+func NewInMemoryJobService() *InMemoryJobService {
+	return &InMemoryJobService{
+		jobs: map[string]*Job{},
+	}
+}
+
+// StartJob starts a new job
+func (s *InMemoryJobService) StartJob(id string, work func(updates chan<- string)) (*Job, error) {
+
+	job := s.jobs[id]
+	if job != nil {
+		return nil, ErrJobAlreadyExists
+	}
+
+	log.Println("Starting job with ID " + id)
+	job = NewJob(id, work)
+	s.jobs[id] = job
+
+	job.Start()
+
+	go func() {
+		job.WaitForFinish()
+		log.Printf("Job complete (%v), cleaning up", id)
+		delete(s.jobs, id)
+	}()
+
+	return job, nil
+}
+
+// GetJob retrieves a Subscription for the given ID
+func (s *InMemoryJobService) GetJob(id string) (*Job, error) {
+	job := s.jobs[id]
+	if job == nil {
+		return nil, ErrJobDoesNotExist
+	}
+
+	return job, nil
+}
+
+// StartSubscription creates a subscription for a job
+func (s *InMemoryJobService) StartSubscription(jobID string) (*Subscription, error) {
+	job := s.jobs[jobID]
+	if job == nil {
+		return nil, ErrJobDoesNotExist
+	}
+
+	return job.Subscribe(), nil
+}
+
+// StopSubscription cancels a subscription for a job
+func (s *InMemoryJobService) StopSubscription(receipt *Subscription) error {
+	job := s.jobs[receipt.JobID]
+	job.Unsubscribe(receipt)
+
+	return nil
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/pkg/jobs/service_test.go
+++ b/pkg/jobs/service_test.go
@@ -1,0 +1,153 @@
+package jobs_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joincivil/go-common/pkg/jobs"
+)
+
+func TestInMemoryJobService(t *testing.T) {
+	jobsService := jobs.NewInMemoryJobService()
+
+	testFunc := func(updates chan<- string) {
+		time.Sleep(3 * time.Second)
+		updates <- "step1"
+		time.Sleep(4 * time.Second)
+		updates <- "step2"
+	}
+
+	id := "id1"
+
+	_, err := jobsService.StartJob(id, testFunc)
+	if err != nil {
+		t.Fatalf("Should have started the job: err: %v", err)
+	}
+
+	_, err = jobsService.GetJob(id)
+	if err != nil {
+		t.Errorf("Should have retrieved the job: err: %v", err)
+	}
+}
+func TestInMemoryJobServiceNoJob(t *testing.T) {
+	jobsService := jobs.NewInMemoryJobService()
+
+	id := "id1"
+	_, err := jobsService.GetJob(id)
+	if err == nil {
+		t.Errorf("Should not have retrieved the job: err: %v", err)
+	}
+}
+func TestInMemoryJobServiceSameJob(t *testing.T) {
+	jobsService := jobs.NewInMemoryJobService()
+
+	testFunc := func(updates chan<- string) {
+		time.Sleep(3 * time.Second)
+		updates <- "step1"
+		time.Sleep(4 * time.Second)
+		updates <- "step2"
+	}
+
+	id := "id1"
+
+	_, err := jobsService.StartJob(id, testFunc)
+	if err != nil {
+		t.Fatalf("Should have started the job: err: %v", err)
+	}
+
+	_, err = jobsService.StartJob(id, testFunc)
+	if err == nil {
+		t.Fatalf("Should have failed to start a job with same ID: err: %v", err)
+	}
+}
+
+func TestInMemoryJobServiceSubscribe(t *testing.T) {
+	jobsService := jobs.NewInMemoryJobService()
+
+	testFunc := func(updates chan<- string) {
+		time.Sleep(2 * time.Second)
+		updates <- "step1"
+		time.Sleep(2 * time.Second)
+		updates <- "step2"
+	}
+
+	id := "id1"
+
+	_, err := jobsService.StartJob(id, testFunc)
+	if err != nil {
+		t.Fatalf("Should have started the job: err: %v", err)
+	}
+
+	sub, err := jobsService.StartSubscription(id)
+	if err != nil {
+		t.Fatalf("Should have gotten a subscription: err: %v", err)
+	}
+
+	updateCount := 0
+Loop:
+	for {
+		select {
+		case <-sub.Updates:
+			updateCount++
+			if updateCount == 2 {
+				break Loop
+			}
+		case <-time.After(10 * time.Second):
+			t.Errorf("Should have received all the updates")
+			break Loop
+		}
+	}
+}
+
+func TestInMemoryJobServiceSubscribeNoJob(t *testing.T) {
+	jobsService := jobs.NewInMemoryJobService()
+
+	testFunc := func(updates chan<- string) {
+		time.Sleep(2 * time.Second)
+		updates <- "step1"
+		time.Sleep(2 * time.Second)
+		updates <- "step2"
+	}
+
+	id := "id1"
+
+	_, err := jobsService.StartJob(id, testFunc)
+	if err != nil {
+		t.Fatalf("Should have started the job: err: %v", err)
+	}
+
+	badId := "id2"
+	_, err = jobsService.StartSubscription(badId)
+	if err == nil {
+		t.Fatalf("Should have failed to get subscription: err: %v", err)
+	}
+}
+
+func TestInMemoryJobServiceSubscribeStopSub(t *testing.T) {
+	jobsService := jobs.NewInMemoryJobService()
+
+	testFunc := func(updates chan<- string) {
+		time.Sleep(2 * time.Second)
+		updates <- "step1"
+		time.Sleep(2 * time.Second)
+		updates <- "step2"
+	}
+
+	id := "id1"
+
+	_, err := jobsService.StartJob(id, testFunc)
+	if err != nil {
+		t.Fatalf("Should have started the job: err: %v", err)
+	}
+
+	sub, err := jobsService.StartSubscription(id)
+	if err != nil {
+		t.Fatalf("Should not have failed to get subscription: err: %v", err)
+	}
+
+	err = jobsService.StopSubscription(sub)
+	if err != nil {
+		t.Fatalf("Should not have failed to stop subscription: err: %v", err)
+	}
+
+}


### PR DESCRIPTION
This is to move Dan's work from a branch in `civil-api-server` to this repo, since I can see multiple uses for this code.  Can be integrated anywhere we need to run a long job and report on completion.  Also very useful to track the completion of a transaction internally if needed.

- Adds service to run concurrent jobs until completion, pinging an update channel with status of job.
- Adds a transaction listener which uses the job service to wait until a transaction has completed.
- Adds some additional tests for the job service implementation. 

Part of larger work to add polling to the Newsroom signup APIs for completion of contract/application transactions.

Will need to look into adding a persistent JobService implementation, because if we bounce api-server or any of our processes, the jobs will be lost.
