### PR TITLE
CIVIL-366 - Adds Support to Add Emails to Mailchimp Lists

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -182,6 +182,14 @@
   version = "v1.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:66e942c52d4b0b3de846e8db3f9d4f9554873dd17798486743fb02b3c2bfed59"
+  name = "github.com/mattbaird/gochimp"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a267553896d1cbd0ccfc259ad5442e62bdc3d30d"
+
+[[projects]]
   digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"
   name = "github.com/pborman/uuid"
   packages = ["."]
@@ -478,6 +486,7 @@
     "github.com/ethereum/go-ethereum/event",
     "github.com/golang/glog",
     "github.com/kelseyhightower/envconfig",
+    "github.com/mattbaird/gochimp",
     "github.com/sendgrid/sendgrid-go",
     "github.com/sendgrid/sendgrid-go/helpers/mail",
   ]

--- a/pkg/email/mailchimp.go
+++ b/pkg/email/mailchimp.go
@@ -1,0 +1,80 @@
+// build +integration
+
+package email
+
+// NOTE(PN): Mainly use this Mailchimp library to add addresses to mailing lists for.
+// Mainly use the Emailer via Sendgrid for delivery of emails.
+
+import (
+	"github.com/mattbaird/gochimp"
+)
+
+// NewMailchimpAPI is a convenience function to instantiate a new MailChimpAPI
+// struct
+func NewMailchimpAPI(apiKey string) *MailchimpAPI {
+	chimpAPI := gochimp.NewChimp(apiKey, true)
+	return &MailchimpAPI{
+		api:    chimpAPI,
+		apiKey: apiKey,
+	}
+}
+
+// MailchimpAPI is a wrapper around the MailChimp API.  Uses the gochimp lib.
+type MailchimpAPI struct {
+	apiKey string
+	api    *gochimp.ChimpAPI
+}
+
+// IsSubscribedToList returns true if an email is subscribed on a specified list
+func (m *MailchimpAPI) IsSubscribedToList(listID string, email string) (bool, error) {
+	chimpEmail := gochimp.Email{Email: email}
+	memberInfo := gochimp.ListsMemberInfo{
+		ListId: listID,
+		Emails: []gochimp.Email{chimpEmail},
+	}
+
+	res, err := m.api.MemberInfo(memberInfo)
+	if err != nil {
+		return false, err
+	}
+
+	if res.SuccessCount <= 0 {
+		return false, nil
+	}
+
+	for _, info := range res.MemberInfoRecords {
+		if info.Email == email {
+			if info.Status == "subscribed" {
+				return true, nil
+			}
+			break
+		}
+	}
+
+	return false, nil
+}
+
+// SubscribeToList adds an email address to a specified list
+func (m *MailchimpAPI) SubscribeToList(listID string, email string) error {
+	chimpEmail := gochimp.Email{Email: email}
+	subscriber := gochimp.ListsSubscribe{
+		ListId:      listID,
+		Email:       chimpEmail,
+		DoubleOptIn: false,
+	}
+
+	_, err := m.api.ListsSubscribe(subscriber)
+	return err
+}
+
+// UnsubscribeFromList removes an email address from a specified list
+func (m *MailchimpAPI) UnsubscribeFromList(listID string, email string, delete bool) error {
+	chimpEmail := gochimp.Email{Email: email}
+	unsub := gochimp.ListsUnsubscribe{
+		ListId:       listID,
+		Email:        chimpEmail,
+		DeleteMember: delete,
+	}
+
+	return m.api.ListsUnsubscribe(unsub)
+}

--- a/vendor/github.com/mattbaird/gochimp/.gitignore
+++ b/vendor/github.com/mattbaird/gochimp/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+
+.DS_Store

--- a/vendor/github.com/mattbaird/gochimp/LICENSE
+++ b/vendor/github.com/mattbaird/gochimp/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/vendor/github.com/mattbaird/gochimp/README.md
+++ b/vendor/github.com/mattbaird/gochimp/README.md
@@ -1,0 +1,82 @@
+gochimp
+=======
+
+[![GoDoc](https://godoc.org/github.com/mattbaird/gochimp?status.svg)](https://godoc.org/github.com/mattbaird/gochimp)
+
+Go based API for Mailchimp, starting with Mandrill.
+
+To run tests, set a couple env variables.
+(replacing values with your own mandrill credentials):
+```bash
+$ export MANDRILL_KEY=111111111-1111-1111-1111-111111111
+$ export MANDRILL_USER=user@domain.com
+```
+
+Mandrill Status
+===============
+* API Feature complete on Oct 26/2012
+* Adding tests, making naming conventions consistent, and refactoring error handling
+
+Chimp Status
+============
+* Not started
+
+Getting Started
+===============
+Below is an example approach to rendering custom content into a Mandrill
+template called "welcome email" and sending the rendered email.
+
+```
+package main
+
+import (
+	"fmt"
+	"github.com/mattbaird/gochimp"
+	"os"
+)
+
+func main() {
+	apiKey := os.Getenv("MANDRILL_KEY")
+	mandrillApi, err := gochimp.NewMandrill(apiKey)
+
+	if err != nil {
+		fmt.Println("Error instantiating client")
+	}
+
+	templateName := "welcome email"
+	contentVar := gochimp.Var{"main", "<h1>Welcome aboard!</h1>"}
+	content := []gochimp.Var{contentVar}
+
+	_, err = mandrillApi.TemplateAdd(templateName, fmt.Sprintf("%s", contentVar.Content), true)
+	if err != nil {
+		fmt.Println("Error adding template: %v", err)
+		return
+	}
+	defer mandrillApi.TemplateDelete(templateName)
+	renderedTemplate, err := mandrillApi.TemplateRender(templateName, content, nil)
+
+	if err != nil {
+		fmt.Println("Error rendering template: %v", err)
+		return
+	}
+
+	recipients := []gochimp.Recipient{
+		gochimp.Recipient{Email: "person@place.com"},
+	}
+
+	message := gochimp.Message{
+		Html:      renderedTemplate,
+		Subject:   "Welcome aboard!",
+		FromEmail: "person@place.com",
+		FromName:  "Boss Man",
+		To:        recipients,
+	}
+
+	_, err = mandrillApi.MessageSend(message, false)
+
+	if err != nil {
+		fmt.Println("Error sending message")
+	}
+}
+
+```

--- a/vendor/github.com/mattbaird/gochimp/api.go
+++ b/vendor/github.com/mattbaird/gochimp/api.go
@@ -1,0 +1,189 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+The API package provides the basic support for using HTTP to talk to the Mandrill and Mailchimp API's.
+Each Struct contains a Key, Transport and endpoint property
+*/
+package gochimp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+const (
+	mandrill_uri     = "mandrillapp.com"
+	mandrill_version = "/api/1.0"
+)
+
+type MandrillAPI struct {
+	Key       string
+	Transport http.RoundTripper
+	Timeout   time.Duration
+	endpoint  string
+}
+
+type ChimpAPI struct {
+	Key       string
+	Transport http.RoundTripper
+	Timeout   time.Duration
+	endpoint  string
+}
+
+// see https://mandrillapp.com/api/docs/
+// currently supporting json output formats
+func NewMandrill(apiKey string) (*MandrillAPI, error) {
+	u := url.URL{}
+	u.Scheme = "https"
+	u.Host = mandrill_uri
+	u.Path = mandrill_version
+	return &MandrillAPI{Key: apiKey, endpoint: u.String()}, nil
+}
+
+const mailchimp_uri string = "%s.api.mailchimp.com"
+const mailchimp_version string = "/2.0"
+const debug bool = false
+
+var mailchimp_datacenter = regexp.MustCompile("[a-z]+[0-9]+$")
+
+func NewChimp(apiKey string, https bool) *ChimpAPI {
+	u := url.URL{}
+	if https {
+		u.Scheme = "https"
+	} else {
+		u.Scheme = "http"
+	}
+	u.Host = fmt.Sprintf("%s.api.mailchimp.com", mailchimp_datacenter.FindString(apiKey))
+	u.Path = mailchimp_version
+	return &ChimpAPI{Key: apiKey, endpoint: u.String()}
+}
+
+func runChimp(api *ChimpAPI, path string, parameters interface{}) ([]byte, error) {
+	b, err := json.Marshal(parameters)
+	if err != nil {
+		return nil, err
+	}
+	requestUrl := fmt.Sprintf("%s%s", api.endpoint, path)
+	if debug {
+		log.Printf("Request URL:%s", requestUrl)
+	}
+	client := &http.Client{Transport: api.Transport}
+	if api.Timeout > 0 {
+		client.Timeout = api.Timeout
+	}
+	resp, err := client.Post(requestUrl, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if debug {
+		log.Printf("Response Body:%s", string(body))
+	}
+	if err = chimpErrorCheck(body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func runMandrill(api *MandrillAPI, path string, parameters map[string]interface{}) ([]byte, error) {
+	if parameters == nil {
+		parameters = make(map[string]interface{})
+	}
+	parameters["key"] = api.Key
+	b, err := json.Marshal(parameters)
+	if debug {
+		log.Printf("Payload:%s", string(b))
+	}
+	if err != nil {
+		return nil, err
+	}
+	requestUrl := fmt.Sprintf("%s%s", api.endpoint, path)
+	if debug {
+		log.Printf("Request URL:%s", requestUrl)
+	}
+	client := &http.Client{Transport: api.Transport}
+	if api.Timeout > 0 {
+		client.Timeout = api.Timeout
+	}
+	resp, err := client.Post(requestUrl, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if debug {
+		log.Printf("Response Body:%s", string(body))
+	}
+	if err = mandrillErrorCheck(body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func parseString(body []byte, err error) (string, error) {
+	if err != nil {
+		return "", err
+	}
+	return strconv.Unquote(string(body))
+}
+
+func parseMandrillJson(api *MandrillAPI, path string, parameters map[string]interface{}, retval interface{}) error {
+	body, err := runMandrill(api, path, parameters)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, retval); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseChimpJson(api *ChimpAPI, method string, parameters interface{}, retval interface{}) error {
+	body, err := runChimp(api, method, parameters)
+
+	if err != nil {
+		return err
+	}
+	if retval != nil {
+		return parseJson(body, retval)
+	}
+	return nil
+}
+
+type JsonAlterer interface {
+	alterJson(b []byte) []byte
+}
+
+func parseJson(body []byte, retval interface{}) error {
+	switch r := retval.(type) {
+	case JsonAlterer:
+		return json.Unmarshal(r.alterJson(body), retval)
+	default:
+		return json.Unmarshal(body, retval)
+	}
+}

--- a/vendor/github.com/mattbaird/gochimp/chimp.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp.go
@@ -1,0 +1,72 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type APIError struct {
+	Status string `json:"status"`
+	Code   int    `json:"code"`
+	Name   string `json:"name"`
+	Err    string `json:"error"`
+}
+
+func (e APIError) Error() string {
+	return fmt.Sprintf("%v: %v", e.Code, e.Err)
+}
+
+func chimpErrorCheck(body []byte) error {
+	var e APIError
+	json.Unmarshal(body, &e)
+	if e.Err != "" || e.Code != 0 {
+		return e
+	}
+	return nil
+}
+
+//Mailchimp does not conform to RFC3339 format, so we need custom UnmarshalJSON
+type APITime struct {
+	time.Time
+}
+
+func (t *APITime) UnmarshalJSON(data []byte) (err error) {
+	s := string(data)
+	l := len(s)
+	switch {
+	case l == 12:
+		t.Time, err = time.Parse(`"2006-01-02"`, s)
+	case l == 21:
+		t.Time, err = time.Parse(`"2006-01-02 15:04:05"`, s)
+	case l == 27:
+		t.Time, err = time.Parse(`"2006-01-02 15:04:05.00000"`, s)
+	case l == 9:
+		t.Time, err = time.Parse(`"2006-01"`, s)
+	}
+	return
+}
+
+//format string for time.Format
+const APITimeFormat = "2006-01-02 15:04:05"
+
+func apiTime(t interface{}) interface{} {
+	switch ti := t.(type) {
+	case time.Time:
+		return ti.Format(APITimeFormat)
+	case string:
+		return ti
+	}
+	return t
+}

--- a/vendor/github.com/mattbaird/gochimp/chimp_campaigns.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_campaigns.go
@@ -1,0 +1,272 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	get_content_endpoint     string = "/campaigns/content.%s"
+	campaign_create_endpoint string = "/campaigns/create.json"
+	campaign_send_endpoint   string = "/campaigns/send.json"
+	campaign_list_endpoint   string = "/campaigns/list.json"
+)
+
+func (a *ChimpAPI) GetContentAsXML(cid string, options map[string]interface{}) (ContentResponse, error) {
+	return a.GetContent(cid, options, "xml")
+}
+
+func (a *ChimpAPI) GetContentAsJson(cid string, options map[string]interface{}) (ContentResponse, error) {
+	return a.GetContent(cid, options, "json")
+}
+
+func (a *ChimpAPI) GetContent(cid string, options map[string]interface{}, contentFormat string) (ContentResponse, error) {
+	var response ContentResponse
+	if !strings.EqualFold(strings.ToLower(contentFormat), "xml") && strings.EqualFold(strings.ToLower(contentFormat), "json") {
+		return response, fmt.Errorf("contentFormat should be one of xml or json, you passed an unsupported value %s", contentFormat)
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["apikey"] = a.Key
+	params["cid"] = cid
+	params["options"] = options
+	err := parseChimpJson(a, fmt.Sprintf(get_content_endpoint, contentFormat), params, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) CampaignCreate(req CampaignCreate) (CampaignResponse, error) {
+	req.ApiKey = a.Key
+	var response CampaignResponse
+	err := parseChimpJson(a, campaign_create_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) CampaignSend(cid string) (CampaignSendResponse, error) {
+	req := campaignSend{
+		ApiKey:     a.Key,
+		CampaignId: cid,
+	}
+	var response CampaignSendResponse
+	err := parseChimpJson(a, campaign_send_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) CampaignList(req CampaignList) (CampaignListResponse, error) {
+	req.ApiKey = a.Key
+	var response CampaignListResponse
+	err := parseChimpJson(a, campaign_list_endpoint, req, &response)
+	return response, err
+}
+
+type CampaignListResponse struct {
+	Total     int                `json:"total"`
+	Campaigns []CampaignResponse `json:"data"`
+}
+
+type CampaignList struct {
+	// A valid API Key for your user account. Get by visiting your API dashboard
+	ApiKey string `json:"apikey"`
+
+	// Filters to apply to this query - all are optional:
+	Filter CampaignListFilter `json:"filters,omitempty"`
+
+	// Control paging of campaigns, start results at this campaign #,
+	// defaults to 1st page of data (page 0)
+	Start int `json:"start,omitempty"`
+
+	// Control paging of campaigns, number of campaigns to return with each call, defaults to 25 (max=1000)
+	Limit int `json:"limit,omitempty"`
+
+	// One of "create_time", "send_time", "title", "subject". Invalid values
+	// will fall back on "create_time" - case insensitive.
+	SortField string `json:"sort_field,omitempty"`
+
+	// "DESC" for descending (default), "ASC" for Ascending. Invalid values
+	// will fall back on "DESC" - case insensitive.
+	OrderOrder string `json:"sort_dir,omitempty"`
+}
+
+type CampaignListFilter struct {
+	// Return the campaign using a know campaign_id. Accepts
+	// multiples separated by commas when not using exact matching.
+	CampaignID string `json:"campaign_id,omitempty"`
+
+	// Return the child campaigns using a known parent campaign_id.
+	// Accepts multiples separated by commas when not using exact matching.
+	ParentID string `json:"parent_id,omitempty"`
+
+	// The list to send this campaign to - Get lists using ListList.
+	// Accepts multiples separated by commas when not using exact matching.
+	ListID string `json:"list_id,omitempty"`
+
+	// Only show campaigns from this folder id - get folders using FoldersList.
+	// Accepts multiples separated by commas when not using exact matching.
+	FolderID int `json:"folder_id,omitempty"`
+
+	// Only show campaigns using this template id - get templates using TemplatesList.
+	// Accepts multiples separated by commas when not using exact matching.
+	TemplateID int `json:"template_id,omitempty"`
+
+	// Return campaigns of a specific status - one of "sent", "save", "paused", "schedule", "sending".
+	// Accepts multiples separated by commas when not using exact matching.
+	Status string `json:"status,omitempty"`
+
+	// Return campaigns of a specific type - one of "regular", "plaintext", "absplit", "rss", "auto".
+	// Accepts multiples separated by commas when not using exact matching.
+	Type string `json:"type,omitempty"`
+
+	// Only show campaigns that have this "From Name"
+	FromName string `json:"from_name,omitempty"`
+
+	// Only show campaigns that have this "Reply-to Email"
+	FromEmail string `json:"from_email,omitempty"`
+
+	// Only show campaigns that have this title
+	Title string `json:"title"`
+
+	// Only show campaigns that have this subject
+	Subject string `json:"subject"`
+
+	// Only show campaigns that have been sent since this date/time (in GMT) - -
+	// 24 hour format in GMT, eg "2013-12-30 20:30:00" - if this is invalid the whole call fails
+	SendTimeStart string `json:"sendtime_start,omitempty"`
+
+	// Only show campaigns that have been sent before this date/time (in GMT) - -
+	// 24 hour format in GMT, eg "2013-12-30 20:30:00" - if this is invalid the whole call fails
+	SendTimeEnd string `json:"sendtime_end,omitempty"`
+
+	// Whether to return just campaigns with or without segments
+	UsesSegment bool `json:"uses_segment,omitempty"`
+
+	// Flag for whether to filter on exact values when filtering, or search within content for
+	// filter values - defaults to true. Using this disables the use of any filters that accept multiples.
+	Exact bool `json:"exact,omitempty"`
+}
+
+type campaignSend struct {
+	ApiKey     string `json:"apikey"`
+	CampaignId string `json:"cid"`
+}
+
+type CampaignSendResponse struct {
+	Complete bool `json:"complete"`
+}
+
+type CampaignCreate struct {
+	ApiKey  string                `json:"apikey"`
+	Type    string                `json:"type"`
+	Options CampaignCreateOptions `json:"options"`
+	Content CampaignCreateContent `json:"content"`
+}
+
+type CampaignCreateOptions struct {
+	// ListID is the list to send this campaign to
+	ListID string `json:"list_id"`
+
+	// Title is the title for new campaign
+	Title string `json:"title"`
+	// TemplateID is the user-created template from which the HTML
+	// content of the campaign should be created
+	TemplateID string `json:"template_id"`
+
+	// Subject is the subject line for your campaign message
+	Subject string `json:"subject"`
+
+	// FromEmail is the From: email address for your campaign message
+	FromEmail string `json:"from_email"`
+
+	// FromName is the From: name for your campaign message (not an email address)
+	FromName string `json:"from_name"`
+
+	// ToName is the To: name recipients will see (not email address)
+	ToName string `json:"to_name"`
+}
+
+type CampaignCreateContent struct {
+	// HTML is the raw/pasted HTML content for the campaign
+	HTML string `json:"html"`
+
+	// When using a template instead of raw HTML, each key
+	// in the map should be the unique mc:edit area name from
+	// the template.
+	Sections map[string]string `json:"sections,omitempty"`
+
+	// Text is the plain-text version of the body
+	Text string `json:"text"`
+
+	// MailChimp will pull in content from this URL. Note,
+	// this will override any other content options - for lists
+	// with Email Format options, you'll need to turn on
+	// generate_text as well
+	URL string `json:"url,omitempty"`
+
+	// A Base64 encoded archive file for MailChimp to import all
+	// media from. Note, this will override any other content
+	// options - for lists with Email Format options, you'll
+	// need to turn on generate_text as well
+	Archive string `json:"archive,omitempty"`
+
+	// ArchiveType only applies to the Archive field. Supported
+	// formats are: zip, tar.gz, tar.bz2, tar, tgz, tbz.
+	// If not included, we will default to zip
+	ArchiveType string `json:"archive_options,omitempty"`
+}
+
+type CampaignResponse struct {
+	Id                 string           `json:"id"`
+	WebId              int              `json:"web_id"`
+	ListId             string           `json:"list_id"`
+	FolderId           int              `json:"folder_id"`
+	TemplateId         int              `json:"template_id"`
+	ContentType        string           `json:"content_type"`
+	ContentEditedBy    string           `json:"content_edited_by"`
+	Title              string           `json:"title"`
+	Type               string           `json:"type"`
+	CreateTime         string           `json:"create_time"`
+	SendTime           string           `json:"send_time"`
+	ContentUpdatedTime string           `json:"content_updated_time"`
+	Status             string           `json:"status"`
+	FromName           string           `json:"from_name"`
+	FromEmail          string           `json:"from_email"`
+	Subject            string           `json:"subject"`
+	ToName             string           `json:"to_name"`
+	ArchiveURL         string           `json:"archive_url"`
+	ArchiveURLLong     string           `json:"archive_url_long"`
+	EmailsSent         int              `json:"emails_sent"`
+	Analytics          string           `json:"analytics"`
+	AnalyticsTag       string           `json:"analytics_tag"`
+	InlineCSS          bool             `json:"inline_css"`
+	Authenticate       bool             `json:"authenticate"`
+	Ecommm360          bool             `json:"ecomm360"`
+	AutoTweet          bool             `json:"auto_tweet"`
+	AutoFacebookPort   string           `json:"auto_fb_post"`
+	AutoFooter         bool             `json:"auto_footer"`
+	Timewarp           bool             `json:"timewarp"`
+	TimewarpSchedule   string           `json:"timewarp_schedule,omitempty"`
+	Tracking           CampaignTracking `json:"tracking"`
+	ParentId           string           `json:"parent_id"`
+	IsChild            bool             `json:"is_child"`
+	TestsRemaining     int              `json:"tests_remain"`
+	SegmentText        string           `json:"segment_text"`
+}
+
+type CampaignTracking struct {
+	HTMLClicks bool `json:"html_clicks"`
+	TextClicks bool `json:"text_clicks"`
+	Opens      bool `json:"opens"`
+}
+
+type ContentResponse struct {
+	Html string `json:"html"`
+	Text string `json:"text"`
+}

--- a/vendor/github.com/mattbaird/gochimp/chimp_ecomm.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_ecomm.go
@@ -1,0 +1,12 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp

--- a/vendor/github.com/mattbaird/gochimp/chimp_folders.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_folders.go
@@ -1,0 +1,12 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp

--- a/vendor/github.com/mattbaird/gochimp/chimp_gallery.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_gallery.go
@@ -1,0 +1,12 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp

--- a/vendor/github.com/mattbaird/gochimp/chimp_helper.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_helper.go
@@ -1,0 +1,33 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+const (
+	helper_inline_css = "/helper/inline-css.json"
+)
+
+func (a *ChimpAPI) InlineCSS(req InlineCSSRequest) (InlineCSSResponse, error) {
+	var response InlineCSSResponse
+	req.ApiKey = a.Key
+	err := parseChimpJson(a, helper_inline_css, req, &response)
+	return response, err
+}
+
+type InlineCSSRequest struct {
+	ApiKey   string `json:"apikey"`
+	HTML     string `json:"html"`
+	StripCSS bool   `json:"strip_html"`
+}
+
+type InlineCSSResponse struct {
+	HTML string `json:"html"`
+}

--- a/vendor/github.com/mattbaird/gochimp/chimp_lists.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_lists.go
@@ -1,0 +1,500 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+// see http://apidocs.mailchimp.com/api/2.0/
+const (
+	lists_batch_subscribe_endpoint            string = "/lists/batch-subscribe.json"
+	lists_batch_unsubscribe_endpoint          string = "/lists/batch-unsubscribe.json"
+	lists_interest_group_add_endpoint         string = "/lists/interest-group-add.json"
+	lists_interest_groupings_list_endpoint    string = "/lists/interest-groupings.json"
+	lists_list_endpoint                       string = "/lists/list.json"
+	lists_member_info_endpoint                string = "/lists/member-info.json"
+	lists_members_endpoint                    string = "/lists/members.json"
+	lists_static_segment_add_endpoint         string = "/lists/static-segment-add.json"
+	lists_static_segment_del_endpoint         string = "/lists/static-segment-del.json"
+	lists_static_segment_members_add_endpoint string = "/lists/static-segment-members-add.json"
+	lists_static_segment_members_del_endpoint string = "/lists/static-segment-members-del.json"
+	lists_static_segment_reset_endpoint       string = "/lists/static-segment-reset.json"
+	lists_static_segments_endpoint            string = "/lists/static-segments.json"
+	lists_subscribe_endpoint                  string = "/lists/subscribe.json"
+	lists_unsubscribe_endpoint                string = "/lists/unsubscribe.json"
+	lists_update_member_endpoint              string = "/lists/update-member.json"
+	lists_webhook_add_endpoint                string = "/lists/webhook-add.json"
+	lists_webhook_del_endpoint                string = "/lists/webhook-del.json"
+	lists_webhooks                            string = "/lists/webhooks.json"
+)
+
+func (a *ChimpAPI) BatchSubscribe(req BatchSubscribe) (BatchSubscribeResponse, error) {
+	var response BatchSubscribeResponse
+	req.ApiKey = a.Key
+	err := parseChimpJson(a, lists_batch_subscribe_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) BatchUnsubscribe(req BatchUnsubscribe) (BatchResponse, error) {
+	var response BatchResponse
+	req.ApiKey = a.Key
+	err := parseChimpJson(a, lists_batch_unsubscribe_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) ListsSubscribe(req ListsSubscribe) (Email, error) {
+	var response Email
+	req.ApiKey = a.Key
+	err := parseChimpJson(a, lists_subscribe_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) ListsUnsubscribe(req ListsUnsubscribe) error {
+	req.ApiKey = a.Key
+	return parseChimpJson(a, lists_unsubscribe_endpoint, req, nil)
+}
+
+func (a *ChimpAPI) InterestGroupAdd(req InterestGroupAdd) (InterestGroupAddResponse, error) {
+	req.ApiKey = a.Key
+	var response InterestGroupAddResponse
+	err := parseChimpJson(a, lists_interest_group_add_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) InterestGroupingsList(req InterestGroupingsList) ([]InterestGroupingsListResponse, error) {
+	req.ApiKey = a.Key
+	var response []InterestGroupingsListResponse
+	err := parseChimpJson(a, lists_interest_groupings_list_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) ListsList(req ListsList) (ListsListResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsListResponse
+	err := parseChimpJson(a, lists_list_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) UpdateMember(req UpdateMember) error {
+	req.ApiKey = a.Key
+	return parseChimpJson(a, lists_update_member_endpoint, req, nil)
+}
+
+func (a *ChimpAPI) Members(req ListsMembers) (ListsMembersResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsMembersResponse
+	err := parseChimpJson(a, lists_members_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) MemberInfo(req ListsMemberInfo) (ListsMemberInfoResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsMemberInfoResponse
+	err := parseChimpJson(a, lists_member_info_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) StaticSegments(req ListsStaticSegments) ([]ListsStaticSegmentResponse, error) {
+	req.ApiKey = a.Key
+	var response []ListsStaticSegmentResponse
+	err := parseChimpJson(a, lists_static_segments_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) StaticSegmentAdd(req ListsStaticSegmentAdd) (ListsStaticSegmentAddResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsStaticSegmentAddResponse
+	err := parseChimpJson(a, lists_static_segment_add_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) StaticSegmentDel(req ListsStaticSegment) (ListsStaticSegmentUpdateResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsStaticSegmentUpdateResponse
+	err := parseChimpJson(a, lists_static_segment_del_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) StaticSegmentMembersAdd(req ListsStaticSegmentMembers) (ListsStaticSegmentMembersResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsStaticSegmentMembersResponse
+	err := parseChimpJson(a, lists_static_segment_members_add_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) StaticSegmentMembersDel(req ListsStaticSegmentMembers) (ListsStaticSegmentMembersResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsStaticSegmentMembersResponse
+	err := parseChimpJson(a, lists_static_segment_members_del_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) StaticSegmentReset(req ListsStaticSegment) (ListsStaticSegmentUpdateResponse, error) {
+	req.ApiKey = a.Key
+	var response ListsStaticSegmentUpdateResponse
+	err := parseChimpJson(a, lists_static_segment_reset_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) WebhookAdd(req ChimpWebhookAddRequest) (ChimpWebhookAddResponse, error) {
+	req.ApiKey = a.Key
+	var response ChimpWebhookAddResponse
+	err := parseChimpJson(a, lists_webhook_add_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) WebhookDel(req ChimpWebhookDelRequest) (ChimpWebhookDelResponse, error) {
+	req.ApiKey = a.Key
+	var response ChimpWebhookDelResponse
+	err := parseChimpJson(a, lists_webhook_del_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) Webhooks(req ChimpWebhooksRequest) ([]ChimpWebhook, error) {
+	req.ApiKey = a.Key
+	var response []ChimpWebhook
+	err := parseChimpJson(a, lists_webhooks, req, &response)
+	return response, err
+}
+
+type BatchUnsubscribe struct {
+	ApiKey       string  `json:"apikey"`
+	ListId       string  `json:"id"`
+	Batch        []Email `json:"batch"`
+	DeleteMember bool    `json:"delete_member"`
+	SendGoodbye  bool    `json:"send_goodbye"`
+	SendNotify   bool    `json:"send_notify"`
+}
+
+type BatchSubscribe struct {
+	ApiKey           string        `json:"apikey"`
+	ListId           string        `json:"id"`
+	Batch            []ListsMember `json:"batch"`
+	DoubleOptin      bool          `json:"double_optin"`
+	UpdateExisting   bool          `json:"update_existing"`
+	ReplaceInterests bool          `json:"replace_interests"`
+}
+
+type ListsUnsubscribe struct {
+	ApiKey       string `json:"apikey"`
+	ListId       string `json:"id"`
+	Email        Email  `json:"email"`
+	DeleteMember bool   `json:"delete_member"`
+	SendGoodbye  bool   `json:"send_goodbye"`
+	SendNotify   bool   `json:"send_notify"`
+}
+
+type ListsSubscribe struct {
+	ApiKey           string                 `json:"apikey"`
+	ListId           string                 `json:"id"`
+	Email            Email                  `json:"email"`
+	MergeVars        map[string]interface{} `json:"merge_vars,omitempty"`
+	EmailType        string                 `json:"email_type,omitempty"`
+	DoubleOptIn      bool                   `json:"double_optin"`
+	UpdateExisting   bool                   `json:"update_existing"`
+	ReplaceInterests bool                   `json:"replace_interests"`
+	SendWelcome      bool                   `json:"send_welcome"`
+}
+
+type ListFilter struct {
+	ListId        string `json:"list_id"`
+	ListName      string `json:"list_name"`
+	FromName      string `json:"from_name"`
+	FromEmail     string `json:"from_email"`
+	FromSubject   string `json:"from_subject"`
+	CreatedBefore string `json:"created_before"`
+	CreatedAfter  string `json:"created_after"`
+	Exact         bool   `json:"exact"`
+}
+
+type ListStat struct {
+	MemberCount               float64 `json:"member_count"`
+	UnsubscribeCount          float64 `json:"unsubscribe_count"`
+	CleanedCount              float64 `json:"cleaned_count"`
+	MemberCountSinceSend      float64 `json:"member_count_since_send"`
+	UnsubscribeCountSinceSend float64 `json:"unsubscribe_count_since_send"`
+	CleanedCountSinceSend     float64 `json:"cleaned_count_since_send"`
+	CampaignCount             float64 `json:"campaign_count"`
+	GroupingCount             float64 `json:"grouping_count"`
+	GroupCount                float64 `json:"group_count"`
+	MergeVarCount             float64 `json:"merge_var_count"`
+	AvgSubRate                float64 `json:"avg_sub_rate"`
+	AvgUnsubRate              float64 `json:"avg_unsub_rate"`
+	TargetSubRate             float64 `json:"target_sub_rate"`
+	OpenRate                  float64 `json:"open_rate"`
+	ClickRate                 float64 `json:"click_rate"`
+}
+
+type ListData struct {
+	Id                string   `json:"id"`
+	WebId             int      `json:"web_id"`
+	Name              string   `json:"name"`
+	DateCreated       string   `json:"date_created"`
+	EmailTypeOption   bool     `json:"email_type_option"`
+	UseAwesomeBar     bool     `json:"use_awesomebar"`
+	DefaultFromName   string   `json:"default_from_name"`
+	DefaultFromEmail  string   `json:"default_from_email"`
+	DefaultSubject    string   `json:"default_subject"`
+	DefaultLanguage   string   `json:"default_language"`
+	ListRating        float64  `json:"list_rating"`
+	SubscribeShortUrl string   `json:"subscribe_url_short"`
+	SubscribeLongUrl  string   `json:"subscribe_url_long"`
+	BeamerAddress     string   `json:"beamer_address"`
+	Visibility        string   `json:"visibility"`
+	Stats             ListStat `json:"stats"`
+	Modules           []string `json:"modules"`
+}
+
+type BatchResponse struct {
+	Success     int          `json:"success_count"`
+	ErrorCount  int          `json:"error_count"`
+	BatchErrors []BatchError `json:"errors"`
+}
+
+type BatchSubscribeResponse struct {
+	AddCount    int                    `json:"add_count"`
+	Adds        []Email                `json:"adds"`
+	UpdateCount int                    `json:"update_count"`
+	Updates     []Email                `json:"updates"`
+	ErrorCount  int                    `json:"error_count"`
+	Error       []BatchSubscriberError `json:"errors"`
+}
+
+type BatchError struct {
+	Emails Email  `json:"email"`
+	Code   int    `json:"code"`
+	Error  string `json:"error"`
+}
+
+type BatchSubscriberError struct {
+	Emails Email       `json:"email"`
+	Code   int         `json:"code"`
+	Error  string      `json:"error"`
+	Row    interface{} `json:"row"`
+}
+
+type ListError struct {
+	Param string `json:"param"`
+	Code  int    `json:"code"`
+	Error string `json:"error"`
+}
+
+type ListsListResponse struct {
+	Total  int         `json:"total"`
+	Data   []ListData  `json:"data"`
+	Errors []ListError `json:"errors"`
+}
+
+type ListsList struct {
+	ApiKey        string     `json:"apikey"`
+	Filters       ListFilter `json:"filters,omitempty"`
+	Start         int        `json:"start,omitempty"`
+	Limit         int        `json:"limit,omitempty"`
+	SortField     string     `json:"sort_field,omitempty"`
+	SortDirection string     `json:"sort_dir,omitempty"`
+}
+
+type UpdateMember struct {
+	ApiKey           string                 `json:"apikey"`
+	ListId           string                 `json:"id"`
+	Email            Email                  `json:"email"`
+	MergeVars        map[string]interface{} `json:"merge_vars,omitempty"`
+	EmailType        string                 `json:"email_type,omitempty"`
+	ReplaceInterests bool                   `json:"replace_interests"`
+}
+
+type Email struct {
+	Email string `json:"email"`
+	Euid  string `json:"euid"`
+	Leid  string `json:"leid"`
+}
+
+type ListsMembers struct {
+	ApiKey  string          `json:"apikey"`
+	ListId  string          `json:"id"`
+	Status  string          `json:"status"`
+	Options ListsMembersOpt `json:"opts,omitempty"`
+}
+
+type ListsMember struct {
+	Email     Email                  `json:"email"`
+	EmailType string                 `json:"emailtype"`
+	MergeVars map[string]interface{} `json:"merge_vars,omitempty"`
+}
+
+type ListsMembersOpt struct {
+	Start         int    `json:"start,omitempty"`
+	Limit         int    `json:"limit,omitempty"`
+	SortField     string `json:"sort_field,omitempty"`
+	SortDirection string `json:"sort_dir,omitempty"`
+}
+
+type ListsMembersResponse struct {
+	Total int          `json:"total"`
+	Data  []MemberInfo `json:"data"`
+}
+
+type ListsMemberInfo struct {
+	ApiKey string  `json:"apikey"`
+	ListId string  `json:"id"`
+	Emails []Email `json:"emails"`
+}
+
+type ListsMemberInfoResponse struct {
+	SuccessCount      int          `json:"success_count"`
+	ErrorCount        int          `json:"error_count"`
+	Errors            []ListError  `json:"errors"`
+	MemberInfoRecords []MemberInfo `json:"data"`
+}
+
+type MemberInfo struct {
+	Email           string                 `json:"email"`
+	Euid            string                 `json:"euid"`
+	EmailType       string                 `json:"email_type"`
+	IpSignup        string                 `json:"ip_signup,omitempty"`
+	TimestampSignup string                 `json:"timestamp_signup,omitempty"`
+	IpOpt           string                 `json:"ip_opt"`
+	TimestampOpt    string                 `json:"timestamp_opt"`
+	MemberRating    int                    `json:"member_rating"`
+	InfoChanged     string                 `json:"info_changed"`
+	Leid            int                    `json:"leid"`
+	Language        string                 `json:"language,omitempty"`
+	ListId          string                 `json:"list_id"`
+	ListName        string                 `json:"list_name"`
+	Merges          map[string]interface{} `json:"merges"`
+	Status          string                 `json:"status"`
+	Timestamp       string                 `json:"timestamp"`
+}
+
+type ListsStaticSegments struct {
+	ApiKey    string `json:"apikey"`
+	ListId    string `json:"id"`
+	GetCounts bool   `json:"get_counts,omitempty"`
+	Start     int    `json:"start,omitempty"`
+	Limit     int    `json:"limit,omitempty"`
+}
+
+type ListsStaticSegmentResponse struct {
+	Id          int    `json:"id"`
+	Name        string `json:"name"`
+	MemberCount int    `json:"member_count"`
+	CreatedDate string `json:"created_date"`
+	LastUpdate  string `json:"last_update"`
+	LastReset   string `json:"last_reset"`
+}
+
+type ListsStaticSegmentAdd struct {
+	ApiKey string `json:"apikey"`
+	ListId string `json:"id"`
+	Name   string `json:"name"`
+}
+
+type ListsStaticSegmentAddResponse struct {
+	Id int `json:"id"`
+}
+
+type ListsStaticSegment struct {
+	ApiKey string `json:"apikey"`
+	ListId string `json:"id"`
+	SegId  int    `json:"seg_id"`
+}
+
+type ListsStaticSegmentUpdateResponse struct {
+	Complete bool `json:"complete"`
+}
+
+type ListsStaticSegmentMembers struct {
+	ApiKey string  `json:"apikey"`
+	ListId string  `json:"id"`
+	SegId  int     `json:"seg_id"`
+	Batch  []Email `json:"batch"`
+}
+
+type ListsStaticSegmentMembersResponse struct {
+	SuccessCount int          `json:"success_count"`
+	ErrorCount   int          `json:"error_count"`
+	Errors       []BatchError `json:"errors"`
+}
+
+type ChimpWebhook struct {
+	Url     string              `json:"url"`
+	Actions ChimpWebhookActions `json:"actions"`
+	Sources ChimpWebhookSources `json:"sources"`
+}
+
+type ChimpWebhookAddRequest struct {
+	ChimpWebhook
+	ApiKey string `json:"apikey"`
+	ListId string `json:"id"`
+}
+
+type ChimpWebhookActions struct {
+	Subscribe   bool `json:"subscribe"`
+	Unsubscribe bool `json:"unsubscribe"`
+	Profile     bool `json:"profile"`
+	Cleaned     bool `json:"cleaned"`
+	Upemail     bool `json:"upemail"`
+	Campaign    bool `json:"campaign"`
+}
+
+type ChimpWebhookSources struct {
+	User  bool `json:"user"`
+	Admin bool `json:"admin"`
+	Api   bool `json:"api"`
+}
+
+type ChimpWebhookAddResponse struct {
+	Id int `json:"id,string"`
+}
+
+type ChimpWebhookDelRequest struct {
+	ApiKey string `json:"apikey"`
+	ListId string `json:"id"`
+	Url    string `json:"url"`
+}
+
+type ChimpWebhookDelResponse struct {
+	Complete bool `json:"complete"`
+}
+
+type ChimpWebhooksRequest struct {
+	ApiKey string `json:"apikey"`
+	ListId string `json:"id"`
+}
+
+type InterestGroupAdd struct {
+	ApiKey     string `json:"apikey"`
+	ListId     string `json:"id"`
+	GroupName  string `json:"group_name"`
+	GroupingId int    `json:"grouping_id,omitempty"`
+}
+
+type InterestGroupAddResponse struct {
+	Complete bool `json:"complete"`
+}
+
+type InterestGroupingsList struct {
+	ApiKey string `json:"apikey"`
+	ListId string `json:"id"`
+	Counts bool   `json:"counts"`
+}
+
+type InterestGroupingsListResponse struct {
+	Id        int          `json:"id"`
+	Name      string       `json:"name"`
+	FormField string       `json:"form_field"`
+	Groups    []ChimpGroup `json:"groups"`
+}
+
+type ChimpGroup struct {
+	Bit          string `json:"bit"`
+	Name         string `json:"name"`
+	DisplayOrder string `json:"display_order"`
+	Subscribers  int    `json:"subscribers"`
+}

--- a/vendor/github.com/mattbaird/gochimp/chimp_reports.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_reports.go
@@ -1,0 +1,73 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+const (
+	reports_summary_endpoint string = "/reports/summary.json"
+	reports_clicks_endpoint  string = "/reports/clicks.json"
+)
+
+func (a *ChimpAPI) GetSummary(req ReportsSummary) (ReportSummaryResponse, error) {
+	req.ApiKey = a.Key
+	var response ReportSummaryResponse
+	err := parseChimpJson(a, reports_summary_endpoint, req, &response)
+	return response, err
+}
+
+func (a *ChimpAPI) GetClicks(req ReportsClicks) (ReportClicksResponse, error) {
+	req.ApiKey = a.Key
+	var response ReportClicksResponse
+	err := parseChimpJson(a, reports_clicks_endpoint, req, &response)
+	return response, err
+}
+
+type ReportsClicks struct {
+	ApiKey     string `json:"apikey"`
+	CampaignId string `json:"cid"`
+}
+
+type ReportClicksResponse struct {
+	Total []TrackedUrl `json:"total"`
+}
+
+type TrackedUrl struct {
+	Url           string  `json:"url"`
+	Clicks        int     `json:"clicks"`
+	ClicksPercent float32 `json:"clicks_percent"`
+	Unique        int     `json:"unique"`
+	UniquePercent float32 `json:"unique_percent"`
+}
+
+type ReportsSummary struct {
+	ApiKey     string `json:"apikey"`
+	CampaignId string `json:"cid"`
+}
+
+type ReportSummaryResponse struct {
+	HardBounce   int         `json:"hard_bounces"`
+	SoftBounce   int         `json:"soft_bounces"`
+	Unsubscribes int         `json:"unsubscribes"`
+	AbuseReports int         `json:"abuse_reports"`
+	Opens        int         `json:"opens"`
+	UniqueOpens  int         `json:"unique_opens"`
+	Clicks       int         `json:"clicks"`
+	UniqueClicks int         `json:"unique_clicks"`
+	EmailsSent   int         `json:"emails_sent"`
+	TimeSeries   []TimeSerie `json:"timeseries"`
+}
+
+type TimeSerie struct {
+	TimeStamp       string `json:"timestamp"`
+	EmailsSent      int    `json:"emails_sent"`
+	UniqueOpens     int    `json:"unique_opens"`
+	RecipientsClick int    `json:"recipients_click"`
+}

--- a/vendor/github.com/mattbaird/gochimp/chimp_templates.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_templates.go
@@ -1,0 +1,138 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+const (
+	chimp_templates_list_endpoint string = "/templates/list.json"
+)
+
+func (a *ChimpAPI) TemplatesList(req TemplatesList) (TemplatesListResponse, error) {
+	req.ApiKey = a.Key
+	var response TemplatesListResponse
+	err := parseChimpJson(a, chimp_templates_list_endpoint, req, &response)
+	return response, err
+}
+
+type TemplateListType struct {
+	User    bool `json:"user"`
+	Gallery bool `json:"gallery"`
+	Base    bool `json:"base"`
+}
+
+type TemplateListFilter struct {
+	Category           string `json:"category"`
+	FolderId           string `json:"folder_id"`
+	IncludeInactive    bool   `json:"include_inactive"`
+	InactiveOnly       bool   `json:"inactive_only"`
+	IncludeDragAndDrop bool   `json:"include_drag_and_drop"`
+}
+
+type UserTemplate struct {
+	Id           int    `json:"id"`
+	Name         string `json:"name"`
+	Layout       string `json:"layout"`
+	Category     string `json:"category"`
+	PreviewImage string `json:"preview_image"`
+	DateCreated  string `json:"date_created"`
+	Active       bool   `json:"active"`
+	EditSource   bool   `json:"edit_source"`
+	FolderId     bool   `json:"folder_id"`
+}
+
+type GalleryTemplate struct {
+	Id           int    `json:"id"`
+	Name         string `json:"name"`
+	Layout       string `json:"layout"`
+	Category     string `json:"category"`
+	PreviewImage string `json:"preview_image"`
+	DateCreated  string `json:"date_created"`
+	Active       bool   `json:"active"`
+	EditSource   bool   `json:"edit_source"`
+}
+
+type TemplatesList struct {
+	ApiKey  string             `json:"apikey"`
+	Types   TemplateListType   `json:"types"`
+	Filters TemplateListFilter `json:"filters"`
+}
+
+type TemplatesListResponse struct {
+	User    []UserTemplate    `json:"user"`
+	Gallery []GalleryTemplate `json:"gallery"`
+}
+
+const (
+	chimp_template_info_endpoint   string = "/templates/info.json"
+	chimp_template_add_endpoint    string = "/templates/add.json"
+	chimp_template_update_endpoint string = "/templates/update.json"
+)
+
+func (a *ChimpAPI) TemplatesInfo(req TemplateInfo) (TemplateInfoResponse, error) {
+	req.ApiKey = a.Key
+	var response TemplateInfoResponse
+	err := parseChimpJson(a, chimp_template_info_endpoint, req, &response)
+	return response, err
+}
+
+type TemplateInfo struct {
+	ApiKey     string `json:"apikey"`
+	TemplateID int    `json:"template_id"`
+	Type       string `json:"type"`
+}
+
+type TemplateInfoResponse struct {
+	DefaultContent interface{}
+	Sections       interface{}
+	Source         string
+	Preview        string
+}
+
+func (a *ChimpAPI) TemplatesAdd(req TemplatesAdd) (TemplatesAddResponse, error) {
+	req.ApiKey = a.Key
+	var response TemplatesAddResponse
+	err := parseChimpJson(a, chimp_template_add_endpoint, req, &response)
+	return response, err
+}
+
+type TemplatesAdd struct {
+	ApiKey   string `json:"apikey"`
+	Name     string `json:"name"`
+	HTML     string `json:"html"`
+	FolderID int    `json:"folder_id,omitempty"`
+}
+
+type TemplatesAddResponse struct {
+	TemplateID int `json:"template_id"`
+}
+
+func (a *ChimpAPI) TemplatesUpdate(req TemplatesUpdate) (TemplatesUpdateResponse, error) {
+	req.ApiKey = a.Key
+	var response TemplatesUpdateResponse
+	err := parseChimpJson(a, chimp_template_update_endpoint, req, &response)
+	return response, err
+}
+
+type TemplatesUpdate struct {
+	ApiKey     string                `json:"apikey"`
+	TemplateID int                   `json:"template_id"`
+	Values     TemplatesUpdateValues `json:"values"`
+}
+
+type TemplatesUpdateValues struct {
+	Name     string `json:"name"`
+	HTML     string `json:"html"`
+	FolderID int    `json:"folder_id,omitempty"`
+}
+
+type TemplatesUpdateResponse struct {
+	Complete bool `json:"complete"`
+}

--- a/vendor/github.com/mattbaird/gochimp/chimp_users.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_users.go
@@ -1,0 +1,12 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp

--- a/vendor/github.com/mattbaird/gochimp/chimp_vip.go
+++ b/vendor/github.com/mattbaird/gochimp/chimp_vip.go
@@ -1,0 +1,12 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp

--- a/vendor/github.com/mattbaird/gochimp/mandrill.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill.go
@@ -1,0 +1,52 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+/*
+ four types of error
+ Invalid_Key
+ - The provided API key is not a valid Mandrill API key
+ ValidationError
+ - The parameters passed to the API call are invalid or not provided when required
+ GeneralError
+ - An unexpected error occurred processing the request. Mandrill developers will be notified.
+ Unknown_Template
+ - The requested template does not exist
+*/
+type MandrillError struct {
+	Status  string `json:"status"`
+	Code    int    `json:"code"`
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+func (e MandrillError) Error() string {
+	return fmt.Sprintf("%v: %v", e.Code, e.Message)
+}
+
+func mandrillErrorCheck(body []byte) error {
+	var e MandrillError
+	err := json.Unmarshal(body, &e)
+	if err == nil {
+		// it may have parsed successfully, however there if
+		// there is no message or error code, it's not an error
+		if e.Message != "" || e.Code > 0 {
+			return e
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_inbound.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_inbound.go
@@ -1,0 +1,169 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"errors"
+)
+
+// see https://mandrillapp.com/api/docs/inbound.JSON.html
+const inbound_domains_endpoint string = "/inbound/domains.json"     //List the domains that have been configured for inbound delivery
+const add_domain_endpoint string = "/inbound/add-domain.json"       //Add an inbound domain to your account
+const check_domain_endpoint string = "/inbound/check-domain.json"   //Check the MX settings for an inbound domain.
+const delete_domain_endpoint string = "/inbound/delete-domain.json" //Delete an inbound domain from the account.
+const routes_endopoint string = "/inbound/routes.json"              //List the mailbox routes defined for an inbound domain
+const add_route_endpoint string = "/inbound/add-route.json"         //Add a new mailbox route to an inbound domain
+const update_route_endpoint string = "/inbound/update-route.json"   //Update the pattern or webhook of an existing inbound mailbox route.
+const delete_route_endpoint string = "/inbound/delete-route.json"   //Delete an existing inbound mailbox route
+const send_raw_endpoint string = "/inbound/send-raw.json"           //Send a raw MIME message to an inbound hook as if it had been sent over SMTP.
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) InboundDomainList() ([]InboundDomain, error) {
+	var response []InboundDomain
+	var params map[string]interface{} = make(map[string]interface{})
+	err := parseMandrillJson(a, inbound_domains_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) InboundDomainAdd(domain string) (InboundDomain, error) {
+	return getInboundDomain(a, domain, add_domain_endpoint)
+}
+
+// can error with one of the following: Invalid_Key, Unknown_InboundDomain, ValidationError, GeneralError
+func (a *MandrillAPI) InboundDomainCheck(domain string) (InboundDomain, error) {
+	return getInboundDomain(a, domain, check_domain_endpoint)
+}
+
+// can error with one of the following: Invalid_Key, Unknown_InboundDomain, ValidationError, GeneralError
+func (a *MandrillAPI) InboundDomainDelete(domain string) (InboundDomain, error) {
+	return getInboundDomain(a, domain, delete_domain_endpoint)
+}
+
+// can error with one of the following: Invalid_Key, Unknown_InboundDomain, ValidationError, GeneralError
+func (a *MandrillAPI) RouteList(domain string) ([]Route, error) {
+	var response []Route
+	if domain == "" {
+		return response, errors.New("domain cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["domain"] = domain
+	err := parseMandrillJson(a, routes_endopoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Key, Unknown_InboundDomain, ValidationError, GeneralError
+func (a *MandrillAPI) RouteAdd(domain string, pattern string, url string) (Route, error) {
+	var response Route
+	if domain == "" {
+		return response, errors.New("domain cannot be blank")
+	}
+	if pattern == "" {
+		return response, errors.New("pattern cannot be blank")
+	}
+	if url == "" {
+		return response, errors.New("url cannot be blank")
+	}
+	return getRoute(a, "", domain, pattern, url, add_route_endpoint)
+}
+
+// can error with one of the following: Invalid_Key, Unknown_InboundDomain, ValidationError, GeneralError
+func (a *MandrillAPI) RouteUpdate(id string, domain string, pattern string, url string) (Route, error) {
+	var response Route
+	if id == "" {
+		return response, errors.New("id cannot be blank")
+	}
+	return getRoute(a, id, domain, pattern, url, update_route_endpoint)
+}
+
+// can error with one of the following: Invalid_Key, Unknown_InboundDomain, ValidationError, GeneralError
+func (a *MandrillAPI) RouteDelete(id string) (Route, error) {
+	var response Route
+	if id == "" {
+		return response, errors.New("id cannot be blank")
+	}
+	return getRoute(a, id, "", "", "", delete_route_endpoint)
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) SendRawMIME(raw_message string, to []string, mail_from string, helo string, client_address string) ([]InboundRecipient, error) {
+	var response []InboundRecipient
+	if raw_message == "" {
+		return response, errors.New("raw_message cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["raw_message"] = raw_message
+	if len(to) > 0 {
+		params["to"] = to
+	}
+	if mail_from != "" {
+		params["mail_from"] = mail_from
+	}
+	if helo != "" {
+		params["helo"] = helo
+	}
+	if client_address != "" {
+		params["client_address"] = client_address
+	}
+
+	err := parseMandrillJson(a, send_raw_endpoint, params, &response)
+	return response, err
+}
+
+func getRoute(a *MandrillAPI, id string, domain string, pattern string, url string, endpoint string) (Route, error) {
+	var params map[string]interface{} = make(map[string]interface{})
+	var response Route
+	if id != "" {
+		params["id"] = id
+	}
+	if domain != "" {
+		params["domain"] = domain
+	}
+	if pattern != "" {
+		params["pattern"] = pattern
+	}
+	if url != "" {
+		params["url"] = url
+	}
+
+	err := parseMandrillJson(a, endpoint, params, &response)
+	return response, err
+}
+
+func getInboundDomain(a *MandrillAPI, domain string, endpoint string) (InboundDomain, error) {
+	if domain == "" {
+		return InboundDomain{}, errors.New("domain cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["domain"] = domain
+	var response InboundDomain
+	err := parseMandrillJson(a, endpoint, params, &response)
+	return response, err
+}
+
+type InboundDomain struct {
+	Domain    string  `json:"domain"`
+	CreatedAt APITime `json:"created_at"`
+	ValidMx   bool    `json:"valid_mx"`
+}
+
+type Route struct {
+	Id      string `json:"id"`
+	Pattern string `json:"pattern"`
+	Url     string `json:"url"`
+}
+
+type InboundRecipient struct {
+	Email   string `json:"email"`
+	Pattern string `json:"pattern"`
+	Url     string `json:"url"`
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_messages.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_messages.go
@@ -1,0 +1,329 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"time"
+)
+
+// see https://mandrillapp.com/api/docs/messages.html
+const messages_send_endpoint string = "/messages/send.json"                   // Send a new transactional message through Mandrill
+const messages_info_endpoint string = "/messages/info.json"                   // Get info about a message
+const messages_send_template_endpoint string = "/messages/send-template.json" // Send a new transactional message through Mandrill using a template
+const messages_search_endpoint string = "/messages/search.json"               // Search the content of recently sent messages and optionally narrow by date range, tags and senders
+const messages_parse_endpoint string = "/messages/parse.json"                 // Parse the full MIME document for an email message, returning the content of the message broken into its constituent pieces
+const messages_send_raw_endpoint string = "/messages/send-raw.json"           // Take a raw MIME document for a message, and send it exactly as if it were sent over the SMTP protocol
+const messages_content_endpoint string = "/messages/content.json"
+
+func (a *MandrillAPI) MessageContent(id string) (*MessageContent, error) {
+	var response MessageContent
+	var params map[string]interface{} = make(map[string]interface{})
+	params["id"] = id
+	err := parseMandrillJson(a, messages_content_endpoint, params, &response)
+	return &response, err
+}
+
+func (a *MandrillAPI) MessageInfo(id string) (map[string]interface{}, error) {
+	var response map[string]interface{}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["id"] = id
+	err := parseMandrillJson(a, messages_info_endpoint, params, &response)
+	return response, err
+}
+
+//todo: add send_at, ip_pool and key to messagesend
+func (a *MandrillAPI) MessageSend(message Message, async bool) ([]SendResponse, error) {
+	var response []SendResponse
+	var params map[string]interface{} = make(map[string]interface{})
+	params["message"] = message
+	params["async"] = async
+	err := parseMandrillJson(a, messages_send_endpoint, params, &response)
+	return response, err
+}
+
+func (a *MandrillAPI) MessageSendTemplate(templateName string, templateContent []Var, message Message, async bool) ([]SendResponse, error) {
+	var response []SendResponse
+	if templateName == "" {
+		return response, errors.New("templateName cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["message"] = message
+	params["template_name"] = templateName
+	params["async"] = async
+	params["template_content"] = templateContent
+	err := parseMandrillJson(a, messages_send_template_endpoint, params, &response)
+	return response, err
+}
+
+func (a *MandrillAPI) MessageSearch(searchRequest SearchRequest) ([]SearchResponse, error) {
+	var response []SearchResponse
+	var params map[string]interface{} = make(map[string]interface{})
+	//todo remove this hack
+	if searchRequest.Query != "" {
+		params["query"] = searchRequest.Query
+	}
+	if !searchRequest.DateFrom.IsZero() {
+		params["date_from"] = searchRequest.DateFrom
+	}
+	if !searchRequest.DateTo.IsZero() {
+		params["date_to"] = searchRequest.DateTo
+	}
+	if len(searchRequest.Tags) > 0 {
+		params["tags"] = searchRequest.Tags
+	}
+	if len(searchRequest.Senders) > 0 {
+		params["senders"] = searchRequest.Senders
+	}
+	params["limit"] = searchRequest.Limit
+	if len(searchRequest.APIKeys) > 0 {
+		params["api_keys"] = searchRequest.APIKeys
+	}
+	err := parseMandrillJson(a, messages_search_endpoint, params, &response)
+	return response, err
+}
+
+func (a *MandrillAPI) MessageParse(rawMessage string, async bool) (Message, error) {
+	var response Message
+	if rawMessage == "" {
+		return response, errors.New("rawMessage cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["raw_message"] = rawMessage
+	err := parseMandrillJson(a, messages_parse_endpoint, params, &response)
+	return response, err
+}
+
+// Can return oneof Invalid_Key, ValidationError or GeneralError
+func (a *MandrillAPI) MessageSendRaw(rawMessage string, to []string, from Recipient, async bool) ([]SendResponse, error) {
+	var response []SendResponse
+	if rawMessage == "" {
+		return response, errors.New("rawMessage cannot be blank")
+	}
+	if len(to) <= 0 {
+		return response, errors.New("You need at least one recipient in the To array")
+	}
+
+	var params map[string]interface{} = make(map[string]interface{})
+	params["raw_message"] = rawMessage
+	params["from_email"] = from.Email
+	params["from_name"] = from.Name
+	params["to"] = to
+	params["async"] = async
+	err := parseMandrillJson(a, messages_send_raw_endpoint, params, &response)
+	return response, err
+}
+
+type TS struct {
+	time.Time
+}
+
+func (t *TS) UnmarshalJSON(data []byte) error {
+	i, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*t = TS{time.Unix(i, 0)}
+
+	return nil
+}
+
+type SearchResponse struct {
+	Timestamp    time.Duration     `json:"ts"`
+	Id           string            `json:"_id"`
+	Sender       string            `json:"sender"`
+	Subject      string            `json:"subject"`
+	Email        string            `json:"email"`
+	Tags         []string          `json:"tags"`
+	Opens        int               `json:"opens"`
+	Clicks       int               `json:"clicks"`
+	State        string            `json:"state"`
+	Diag         string            `json:"diag"`
+	Metadata     map[string]string `json:"metadata"`
+	Template     interface{}       `json:"template"`
+	Resends      []Resend          `json:"resends"`
+	SMTPEvents   []SMTPEvent       `json:"smtp_events"`
+	OpensDetail  []ActivityDetail  `json:"opens_detail"`
+	ClicksDetail []ActivityDetail  `json:"clicks_detail"`
+}
+
+type Resend struct {
+	Timestamp time.Duration `json:"ts"`
+}
+
+type SMTPEvent struct {
+	Timestamp     time.Duration `json:"ts"`
+	Type          string        `json:"type"`
+	Diagnostics   string        `json:"diag"`
+	SourceIP      string        `json:"source_ip"`
+	DestinationIP string        `json:"destination_ip"`
+	Size          int           `json:"size"`
+}
+
+type ActivityDetail struct {
+	Timestamp time.Duration `json:"ts"`
+	IP        string        `json:"ip"`
+	Url       string        `json:"url"`
+	Location  string        `json:"location"`
+	UserAgent string        `json:"ua"`
+}
+
+type SearchRequest struct {
+	Query    string   `json:"query"`
+	DateFrom APITime  `json:"date_from"`
+	DateTo   APITime  `json:"date_to"`
+	Tags     []string `json:"tags"`
+	Senders  []string `json:"senders"`
+	APIKeys  []string `json:"api_keys"`
+	Limit    int      `json:"limit"`
+}
+
+type MessageContent struct {
+	Timestamp TS        `json:"ts"`
+	Id        string    `json:"_id"`
+	FromEmail string    `json:"from_email"`
+	FromName  string    `json:"from_name"`
+	Subject   string    `json:"subject"`
+	To        Recipient `json:"to"`
+	Text      string    `json:"text"`
+	Html      string    `json:"html"`
+}
+
+type Message struct {
+	Html                    string              `json:"html,omitempty"`
+	Text                    string              `json:"text,omitempty"`
+	Subject                 string              `json:"subject"`
+	FromEmail               string              `json:"from_email"`
+	FromName                string              `json:"from_name"`
+	To                      []Recipient         `json:"to"`
+	Headers                 map[string]string   `json:"headers,omitempty"`
+	Important               bool                `json:"important,omitempty"`
+	TrackOpens              bool                `json:"track_opens"`
+	TrackClicks             bool                `json:"track_clicks"`
+	ViewContentLink         bool                `json:"view_content_link,omitempty"`
+	AutoText                bool                `json:"auto_text,omitempty"`
+	AutoHtml                bool                `json:"auto_html,omitempty"`
+	UrlStripQS              bool                `json:"url_strip_qs,omitempty"`
+	InlineCss               bool                `json:"inline_css,omitempty"`
+	PreserveRecipients      bool                `json:"preserve_recipients,omitempty"`
+	BCCAddress              string              `json:"bcc_address,omitempty"`
+	TrackingDomain          string              `json:"tracking_domain,omitempty"`
+	SigningDomain           string              `json:"signing_domain,omitempty"`
+	ReturnPathDomain        string              `json:"return_path_domain,omitempty"`
+	Merge                   bool                `json:"merge,omitempty"`
+	GlobalMergeVars         []Var               `json:"global_merge_vars,omitempty"`
+	MergeVars               []MergeVars         `json:"merge_vars,omitempty"`
+	Tags                    []string            `json:"tags,omitempty"`
+	Subaccount              string              `json:"subaccount,omitempty"`
+	GoogleAnalyticsDomains  []string            `json:"google_analytics_domains,omitempty"`
+	GoogleAnalyticsCampaign []string            `json:"google_analytics_campaign,omitempty"`
+	Metadata                map[string]string   `json:"metadata,omitempty"`
+	RecipientMetadata       []RecipientMetaData `json:"recipient_metadata,omitempty"`
+	Attachments             []Attachment        `json:"attachments,omitempty"`
+	MergeLanguage           string              `json:"merge_language,omitempty"`
+	Images                  []Attachment        `json:"images,omitempty"`
+}
+
+func (m *Message) String() string {
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+func (m *Message) AddHeader(key, value string) {
+	if m.Headers == nil {
+		m.Headers = make(map[string]string)
+	}
+	m.Headers[key] = value
+}
+
+func (m *Message) AddRecipients(r ...Recipient) {
+	m.To = append(m.To, r...)
+}
+
+func (m *Message) AddGlobalMergeVar(globalvars ...Var) {
+	m.GlobalMergeVars = append(m.GlobalMergeVars, globalvars...)
+}
+
+func (m *Message) AddMergeVar(vars ...MergeVars) {
+	m.MergeVars = append(m.MergeVars, vars...)
+}
+
+func (m *Message) AddTag(tags ...string) {
+	m.Tags = append(m.Tags, tags...)
+}
+
+func (m *Message) AddGoogleAnalyticsDomains(domains ...string) {
+	m.GoogleAnalyticsDomains = append(m.GoogleAnalyticsDomains, domains...)
+}
+
+func (m *Message) AddGoogleAnalyticsCampaign(campaigns ...string) {
+	m.GoogleAnalyticsCampaign = append(m.GoogleAnalyticsCampaign, campaigns...)
+}
+
+func (m *Message) AddMetadata(key, value string) {
+	if m.Metadata == nil {
+		m.Metadata = make(map[string]string)
+	}
+	m.Metadata[key] = value
+}
+
+func (m *Message) AddRecipientMetadata(metadata ...RecipientMetaData) {
+	m.RecipientMetadata = append(m.RecipientMetadata, metadata...)
+}
+
+func (m *Message) AddAttachments(attachement ...Attachment) {
+	m.Attachments = append(m.Attachments, attachement...)
+}
+
+func (m *Message) AddImages(image ...Attachment) {
+	m.Images = append(m.Images, image...)
+}
+
+type Attachment struct {
+	Type    string `json:"type"`
+	Name    string `json:"name"`
+	Content string `json:"content"`
+}
+type RecipientMetaData struct {
+	Recipient string            `json:"rcpt"`
+	Vars      map[string]string `json:"values"`
+}
+
+type MergeVars struct {
+	Recipient string `json:"rcpt"`
+	Vars      []Var  `json:"vars"`
+}
+
+type Var struct {
+	Name    string      `json:"name"`
+	Content interface{} `json:"content"`
+}
+
+func NewVar(name string, content interface{}) *Var {
+	return &Var{Name: name, Content: content}
+}
+
+type Recipient struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+}
+
+type SendResponse struct {
+	Email          string `json:"email"`
+	Status         string `json:"status"`
+	Id             string `json:"_id"`
+	RejectedReason string `json:"reject_reason"`
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_rejects.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_rejects.go
@@ -1,0 +1,71 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"errors"
+	"log"
+)
+
+// see https://mandrillapp.com/api/docs/rejects.html
+//Retrieves your email rejection blacklist. You can provide an email address to limit the results.
+// Returns up to 1000 results. By default, entries that have expired are excluded from the results;
+// set include_expired to true to include them.
+const rejects_list_endpoint string = "/rejects/list.json"
+
+//Deletes an email rejection. There is no limit to how many rejections you can remove from your
+// blacklist, but keep in mind that each deletion has an affect on your reputation.
+const rejects_delete_endpoint string = "/rejects/delete.json"
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) RejectsList(email string, includeExpired bool) ([]Reject, error) {
+	var response []Reject
+	if email == "" {
+		return response, errors.New("email cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["email"] = email
+	params["include_expired"] = includeExpired
+	err := parseMandrillJson(a, rejects_list_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Reject, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) RejectsDelete(email string) (bool, error) {
+	var response map[string]interface{}
+	var retval bool = false
+	if email == "" {
+		return retval, errors.New("email cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["email"] = email
+	err := parseMandrillJson(a, rejects_delete_endpoint, params, &response)
+	var ok bool = false
+	if err == nil {
+		retval, ok = response["deleted"].(bool)
+		if ok != true {
+			log.Fatal("Received response with deleted parameter, however type was not bool, this should not happen")
+		}
+	}
+	return retval, err
+}
+
+type Reject struct {
+	Email       string  `json:"email"`
+	Reason      string  `json:"reason"`
+	Detail      string  `json:"detail"`
+	CreatedAt   APITime `json:"created_at"`
+	LastEventAt APITime `json:"last_event_at"`
+	ExpiresAt   APITime `json:"expires_at"`
+	Expired     bool    `json:"expired"`
+	Sender      Sender  `json:"sender"`
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_senders.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_senders.go
@@ -1,0 +1,82 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"errors"
+	"time"
+)
+
+// see https://mandrillapp.com/api/docs/senders.html
+const senders_list_endpoint string = "/senders/list.json"               //Return the senders that have tried to use this account.
+const senders_domains_endpoint string = "/senders/domains.json"         //Returns the sender domains that have been added to this account.
+const senders_info_endpoint string = "/senders/info.json"               //Return more detailed information about a single sender, including aggregates of recent stats
+const senders_time_series_endpoint string = "/senders/time-series.json" //Return the recent history (hourly stats for the last 30 days) for a sender
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) SenderList() ([]Sender, error) {
+	var response []Sender
+	var params map[string]interface{} = make(map[string]interface{})
+	err := parseMandrillJson(a, senders_list_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) SenderDomains() ([]Domain, error) {
+	var response []Domain
+	var params map[string]interface{} = make(map[string]interface{})
+	err := parseMandrillJson(a, senders_domains_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Unknown_Sender, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) SenderInfo(address string) (SenderInfo, error) {
+	var response SenderInfo
+	if address == "" {
+		return response, errors.New("address cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["address"] = address
+	err := parseMandrillJson(a, senders_info_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Unknown_Sender, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) SenderTimeSeries(address string) ([]TimeSeries, error) {
+	var response []TimeSeries
+	if address == "" {
+		return response, errors.New("address cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["address"] = address
+	err := parseMandrillJson(a, senders_time_series_endpoint, params, &response)
+	return response, err
+}
+
+type SenderInfo struct {
+	Address     string    `json:"address"`
+	CreatedAt   time.Time `json:"created_at"`
+	Sent        int32     `json:"sent"`
+	HardBounces int32     `json:"hard_bounces"`
+	SoftBounces int32     `json:"soft_bounces"`
+	Rejects     int32     `json:"rejects"`
+	Complaints  int32     `json:"complaints"`
+	Unsubs      int32     `json:"unsubs"`
+	Opens       int32     `json:"opens"`
+	Clicks      int32     `json:"clicks"`
+	Stats       []Stat    `json:"stats"`
+}
+
+type Domain struct {
+	Domain    string    `json:"domain"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_subaccounts.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_subaccounts.go
@@ -1,0 +1,111 @@
+package gochimp
+
+import (
+	"errors"
+)
+
+const subaccounts_list_endpoint string = "/subaccounts/list.json"
+const subaccounts_add_endpoint string = "/subaccounts/add.json"
+const subaccounts_info_endpoint string = "/subaccounts/info.json"
+const subaccounts_update_endpoint string = "/subaccounts/update.json"
+const subaccounts_delete_endpoint string = "/subaccounts/delete.json"
+const subaccounts_pause_endpoint string = "/subaccounts/pause.json"
+const subaccounts_resume_endpoint string = "/subaccounts/resume.json"
+
+type SubaccountTimeSeries struct {
+	Sent         int32 `json:"sent"`
+	HardBounces  int32 `json:"hard_bounces"`
+	SoftBounces  int32 `json:"soft_bounces"`
+	Rejects      int32 `json:"rejects"`
+	Complaints   int32 `json:"complaints"`
+	Unsubs       int32 `json:"unsubs"`
+	Opens        int32 `json:"opens"`
+	UniqueOpens  int32 `json:"unique_opens"`
+	Clicks       int32 `json:"clicks"`
+	UniqueClicks int32 `json:"unique_clicks"`
+}
+
+type SubaccountInfo struct {
+	Id          string               `json:"id"`
+	Name        string               `json:"name"`
+	Notes       string               `json:"notes"`
+	CustomQuota int32                `json:"custom_quota"`
+	Status      string               `json:"status"`
+	Reputation  int32                `json:"reputation"`
+	CreatedAt   APITime              `json:"created_at"`
+	FirstSentAt APITime              `json:"first_sent_at"`
+	SentWeekly  int32                `json:"sent_weekly"`
+	SentMonthly int32                `json:"sent_monthly"`
+	SentTotal   int32                `json:"sent_total"`
+	SentHourly  int32                `json:"sent_hourly"`
+	HourlyQuota int32                `json:"hourly_quota"`
+	Last30Days  SubaccountTimeSeries `json:"last_30_days"`
+}
+
+func (a *MandrillAPI) SubaccountList() (response []SubaccountInfo, err error) {
+	params := make(map[string]interface{})
+	err = parseMandrillJson(a, subaccounts_list_endpoint, params, &response)
+	return
+}
+
+func (a *MandrillAPI) SubaccountAdd(id string, name string, notes string, custom_quota int32) (response SubaccountInfo, err error) {
+	return a.subaccountCreateOrUpdate(id, subaccounts_add_endpoint, name, notes, custom_quota)
+}
+
+func (a *MandrillAPI) SubaccountInfo(id string) (response SubaccountInfo, err error) {
+	return a.subaccountSimpleInteraction(id, subaccounts_info_endpoint)
+}
+
+func (a *MandrillAPI) SubaccountUpdate(id string, name string, notes string, custom_quota int32) (response SubaccountInfo, err error) {
+	return a.subaccountCreateOrUpdate(id, subaccounts_update_endpoint, name, notes, custom_quota)
+}
+
+func (a *MandrillAPI) SubaccountDelete(id string) (response SubaccountInfo, err error) {
+	return a.subaccountSimpleInteraction(id, subaccounts_delete_endpoint)
+}
+
+func (a *MandrillAPI) SubaccountPause(id string) (response SubaccountInfo, err error) {
+	return a.subaccountSimpleInteraction(id, subaccounts_pause_endpoint)
+}
+
+func (a *MandrillAPI) SubaccountResume(id string) (response SubaccountInfo, err error) {
+	return a.subaccountSimpleInteraction(id, subaccounts_resume_endpoint)
+}
+
+func (a *MandrillAPI) subaccountSimpleInteraction(id, endpoint string) (response SubaccountInfo, err error) {
+	if id == "" {
+		return response, errors.New("id cannot be blank")
+	}
+
+	params := map[string]interface{}{"id": id}
+	err = parseMandrillJson(a, endpoint, params, &response)
+	return
+}
+
+func (a *MandrillAPI) subaccountCreateOrUpdate(id, endpoint string, name string, notes string, custom_quota int32) (response SubaccountInfo, err error) {
+	if id == "" {
+		return response, errors.New("id cannot be blank")
+	}
+
+	if len(id) > 255 {
+		return response, errors.New("id cannot be over 255 characters")
+	}
+
+	if len(name) > 1024 {
+		return response, errors.New("name cannot be over 1024 characters")
+	}
+
+	params := map[string]interface{}{
+		"id":    id,
+		"name":  name,
+		"notes": notes,
+	}
+
+	if custom_quota > 0 {
+		params["custom_quota"] = custom_quota
+	}
+
+	err = parseMandrillJson(a, endpoint, params, &response)
+	return
+
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_tags.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_tags.go
@@ -1,0 +1,105 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"errors"
+)
+
+// see https://mandrillapp.com/api/docs/tags.html
+const tags_list_endpoint string = "/tags/list.json"                       // Return all of the user-defined tag information
+const tags_info_endpoint string = "/tags/info.json"                       // Return more detailed information about a single tag, including aggregates of recent stats
+const tags_time_series_endpoint string = "/tags/time-series.json"         // Return the recent history (hourly stats for the last 30 days) for a tag
+const tags_all_time_series_endpoint string = "/tags/all-time-series.json" // Return the recent history (hourly stats for the last 30 days) for a tag
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TagList() ([]ListResponse, error) {
+	var response []ListResponse
+	var params map[string]interface{} = make(map[string]interface{})
+	err := parseMandrillJson(a, tags_list_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Tag_Name, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TagInfo(tag string) (TagInfo, error) {
+	var response TagInfo
+	if tag == "" {
+		return response, errors.New("tag cannot be blank")
+	}
+
+	var params map[string]interface{} = make(map[string]interface{})
+	params["tag"] = tag
+	err := parseMandrillJson(a, tags_info_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Tag_Name, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TagTimeSeries(tag string) ([]TimeSeries, error) {
+	var response []TimeSeries
+	if tag == "" {
+		return response, errors.New("tag cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["tag"] = tag
+	err := parseMandrillJson(a, tags_time_series_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TagAllTimeSeries() ([]TimeSeries, error) {
+	var response []TimeSeries
+	var params map[string]interface{} = make(map[string]interface{})
+	err := parseMandrillJson(a, tags_all_time_series_endpoint, params, &response)
+	return response, err
+}
+
+type TimeSeries struct {
+	Time         APITime `json:"time"`
+	Sent         int32   `json:"sent"`
+	HardBounces  int32   `json:"hard_bounces"`
+	SoftBounces  int32   `json:"soft_bounces"`
+	Rejects      int32   `json:"rejects"`
+	Complaints   int32   `json:"complaints"`
+	Unsubs       int32   `json:"unsubs"`
+	Opens        int32   `json:"opens"`
+	UniqueOpens  int32   `json:"unique_opens"`
+	Clicks       int32   `json:"clicks"`
+	UniqueClicks int32   `json:"unique_clicks"`
+}
+
+type TagInfo struct {
+	Tag          string `json:"tag"`
+	Reputation   int32  `json:"reputation,omitempty"`
+	Sent         int32  `json:"sent"`
+	HardBounces  int32  `json:"hard_bounces"`
+	SoftBounces  int32  `json:"soft_bounces"`
+	Rejects      int32  `json:"rejects"`
+	Complaints   int32  `json:"complaints"`
+	Unsubs       int32  `json:"unsubs"`
+	Opens        int32  `json:"opens"`
+	Clicks       int32  `json:"clicks"`
+	UniqueOpens  int32  `json:"unique_opens"`
+	UniqueClicks int32  `json:"unique_clicks"`
+	Stats        []Stat `json:"stats,omitempty"`
+}
+
+type ListResponse struct {
+	Tag         string `json:"tag"`
+	Sent        int32  `json:"sent"`
+	HardBounces int32  `json:"hard_bounces"`
+	SoftBounces int32  `json:"soft_bounces"`
+	Rejects     int32  `json:"rejects"`
+	Complaints  int32  `json:"complaints"`
+	Unsubs      int32  `json:"unsubs"`
+	Opens       int32  `json:"opens"`
+	Clicks      int32  `json:"clicks"`
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_templates.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_templates.go
@@ -1,0 +1,148 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"errors"
+	"log"
+)
+
+// see https://mandrillapp.com/api/docs/templates.html
+const templates_add_endpoint string = "/templates/add.json"       //Add a new template
+const templates_info_endpoint string = "/templates/info.json"     //Get the information for an existing template
+const templates_update_endpoint string = "/templates/update.json" //Update the code for an existing template
+// Publish the content for the template. Any new messages sent using this template will start
+//using the content that was previously in draft.
+const templates_publish_endpoint string = "/templates/publish.json"
+const templates_delete_endpoint string = "/templates/delete.json"           //Delete a template
+const templates_list_endpoint string = "/templates/list.json"               //Return a list of all the templates available to this user
+const templates_time_series_endpoint string = "/templates/time-series.json" //Return the recent history (hourly stats for the last 30 days) for a template
+const templates_render_endpoint string = "/templates/render.json"           //Inject content and optionally merge fields into a template, returning the HTML that results
+
+// can error with one of the following: Unknown_Template, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplateAdd(name string, code string, publish bool) (Template, error) {
+	if name == "" {
+		return Template{}, errors.New("name cannot be blank")
+	}
+	if code == "" {
+		return Template{}, errors.New("code cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["name"] = name
+	params["code"] = code
+	params["publish"] = publish
+	return execute(a, params, templates_add_endpoint)
+}
+
+// can error with one of the following: Unknown_Template, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplateInfo(name string) (Template, error) {
+	if name == "" {
+		return Template{}, errors.New("name cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["name"] = name
+	return execute(a, params, templates_info_endpoint)
+}
+
+// can error with one of the following: Unknown_Template, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplateUpdate(name string, code string, publish bool) (Template, error) {
+	if name == "" {
+		return Template{}, errors.New("name cannot be blank")
+	}
+	if code == "" {
+		return Template{}, errors.New("code cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["name"] = name
+	params["code"] = code
+	params["publish"] = publish
+	return execute(a, params, templates_update_endpoint)
+}
+
+// can error with one of the following: Unknown_Template, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplatePublish(name string) (Template, error) {
+	if name == "" {
+		return Template{}, errors.New("name cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["name"] = name
+	return execute(a, params, templates_publish_endpoint)
+}
+
+// can error with one of the following: Unknown_Template, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplateDelete(name string) (Template, error) {
+	if name == "" {
+		return Template{}, errors.New("name cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["name"] = name
+	return execute(a, params, templates_delete_endpoint)
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplateList() ([]Template, error) {
+	var response []Template
+	var params map[string]interface{} = make(map[string]interface{})
+	err := parseMandrillJson(a, templates_list_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Unknown_Template, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplateTimeSeries(name string) ([]Template, error) {
+	if name == "" {
+		return []Template{}, errors.New("name cannot be blank")
+	}
+	var response []Template
+	var params map[string]interface{} = make(map[string]interface{})
+	params["name"] = name
+	err := parseMandrillJson(a, templates_time_series_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Unknown_Template, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) TemplateRender(templateName string, templateContent []Var, mergeVars []Var) (string, error) {
+	if templateName == "" {
+		return "", errors.New("templateName cannot be blank")
+	}
+	var response map[string]interface{}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["template_name"] = templateName
+	params["template_content"] = templateContent
+	params["merge_vars"] = mergeVars
+	err := parseMandrillJson(a, templates_render_endpoint, params, &response)
+	var retval string = ""
+	var ok bool = false
+	if err == nil {
+		retval, ok = response["html"].(string)
+		if ok != true {
+			log.Fatal("Received response with html parameter, however type was not string, this should not happen")
+		}
+	}
+	return retval, err
+}
+
+func execute(a *MandrillAPI, params map[string]interface{}, endpoint string) (Template, error) {
+	var response Template
+	err := parseMandrillJson(a, endpoint, params, &response)
+	return response, err
+}
+
+type Template struct {
+	Name        string  `json:"name"`
+	Code        string  `json:"code"`
+	PublishName string  `json:"publish_name"`
+	PublishCode string  `json:"publish_code"`
+	Slug        string  `json:"slug"`
+	Subject     string  `json:"subject"`
+	CreatedAt   APITime `json:"published_at"`
+	UpdateAt    APITime `json:"updated_at"`
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_urls.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_urls.go
@@ -1,0 +1,67 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"errors"
+)
+
+// see https://mandrillapp.com/api/docs/urls.html
+const urls_list_endpoint string = "/urls/list.json"               //Get the 100 most clicked URLs
+const urls_search_endpoint string = "/urls/search.json"           //Return the 100 most clicked URLs that match the search query given
+const urls_time_series_endpoint string = "/urls/time-series.json" //Return the recent history (hourly stats for the last 30 days) for a url
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) UrlList() ([]UrlInfo, error) {
+	var response []UrlInfo
+	var params map[string]interface{} = make(map[string]interface{})
+	err := parseMandrillJson(a, urls_list_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) UrlSearch(q string) ([]UrlInfo, error) {
+	var response []UrlInfo
+	if q == "" {
+		return response, errors.New("query[q] cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["q"] = q
+	err := parseMandrillJson(a, urls_search_endpoint, params, &response)
+	return response, err
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) UrlTimeSeries(url string) ([]UrlInfo, error) {
+	var response []UrlInfo
+	if url == "" {
+		return response, errors.New("url cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["url"] = url
+	err := parseMandrillJson(a, urls_time_series_endpoint, params, &response)
+	return response, err
+}
+
+type UrlTimeSeriesInfo struct {
+	Time         APITime `json:"time"`
+	Sent         int     `json:"sent"`
+	Clicks       int     `json:"clicks"`
+	UniqueClicks int     `json:"unique_clicks"`
+}
+
+type UrlInfo struct {
+	Url          string `json:"url"`
+	Sent         int    `json:"sent"`
+	Clicks       int    `json:"clicks"`
+	UniqueClicks int    `json:"unique_clicks"`
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_users.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_users.go
@@ -1,0 +1,82 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import (
+	"encoding/json"
+)
+
+// see https://mandrillapp.com/api/docs/users.html
+const users_info_endpoint string = "/users/info.json"       //Return the information about the API-connected user
+const users_ping_endpoint string = "/users/ping.json"       // returns "PONG!"
+const users_ping2_endpoint string = "/users/ping2.json"     // returns 'PING':'PONG!' for anal json parsers
+const users_senders_endpoint string = "/users/senders.json" // Return the senders that have tried to use this account, both verified and unverified
+
+func (a *MandrillAPI) Ping() (string, error) {
+	return parseString(runMandrill(a, users_ping_endpoint, nil))
+}
+
+func (a *MandrillAPI) UserInfo() (Info, error) {
+	var info Info
+	err := parseMandrillJson(a, users_info_endpoint, nil, &info)
+	return info, err
+}
+
+func (a *MandrillAPI) UserSenders() ([]Sender, error) {
+	var senders []Sender
+	err := parseMandrillJson(a, users_senders_endpoint, nil, &senders)
+	return senders, err
+}
+
+type Info struct {
+	Username    string          `json:"username"`
+	CreatedAt   APITime         `json:"created_at"`
+	PublicId    string          `json:"public_id"`
+	Reputation  int             `json:"reputation"`
+	HourlyQuota int             `json:"hourly_quota"`
+	Backlog     int             `json:"backlog"`
+	Stats       map[string]Stat `json:"stats"`
+}
+
+type Stat struct {
+	Sent         int `json:"sent"`
+	HardBounces  int `json:"hard_bounces"`
+	SoftBounces  int `json:"soft_bounces"`
+	Rejects      int `json:"rejects"`
+	Complaints   int `json:"complaints"`
+	Unsubs       int `json:"unsubs"`
+	Opens        int `json:"opens"`
+	UniqueOpens  int `json:"unique_opens"`
+	Clicks       int `json:"clicks"`
+	UniqueClicks int `json:"unique_clicks"`
+}
+
+type Sender struct {
+	Sent         int     `json:"sent"`
+	HardBounces  int     `json:"hard_bounces"`
+	SoftBounces  int     `json:"soft_bounces"`
+	Rejects      int     `json:"rejects"`
+	Complaints   int     `json:"complaints"`
+	Unsubs       int     `json:"unsubs"`
+	Opens        int     `json:"opens"`
+	Clicks       int     `json:"clicks"`
+	UniqueOpens  int     `json:"unique_opens"`
+	UniqueClicks int     `json:"unique_clicks"`
+	Reputation   int     `json:"reputation"`
+	Address      string  `json:"address"`
+	CreatedAt    APITime `json:"created_at"`
+}
+
+func (s *Sender) String() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/vendor/github.com/mattbaird/gochimp/mandrill_webhooks.go
+++ b/vendor/github.com/mattbaird/gochimp/mandrill_webhooks.go
@@ -1,0 +1,104 @@
+// Copyright 2013 Matthew Baird
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gochimp
+
+import "errors"
+
+// see https://mandrillapp.com/api/docs/webhooks.html
+const webhooks_list_endpoint string = "/webhooks/list.json"     //Get the list of all webhooks defined on the account
+const webhooks_add_endpoint string = "/webhooks/add.json"       //Add a new webhook
+const webhooks_info_endpoint string = "/webhooks/info.json"     //Given the ID of an existing webhook, return the data about it
+const webhooks_update_endpoint string = "/webhooks/update.json" //Update an existing webhook
+const webhooks_delete_endpoint string = "/webhooks/delete.json" //Delete an existing webhook
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) WebhooksList() (response []Webhook, err error) {
+	var params map[string]interface{} = make(map[string]interface{})
+	err = parseMandrillJson(a, webhooks_list_endpoint, params, &response)
+	return
+}
+
+// can error with one of the following: Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) WebhookAdd(url string, events []string) (Webhook, error) {
+	if url == "" {
+		return Webhook{}, errors.New("url cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["url"] = url
+	params["events"] = events
+	return getWebhook(a, params, webhooks_add_endpoint)
+}
+
+// can error with one of the following: Unknown_Webhook, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) WebhookInfo(id int) (Webhook, error) {
+	if id <= 0 {
+		return Webhook{}, errors.New("id must be >= 0")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["id"] = id
+	return getWebhook(a, params, webhooks_info_endpoint)
+}
+
+// can error with one of the following: Unknown_Webhook, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) WebhookUpdate(url string, events []string) (Webhook, error) {
+	if url == "" {
+		return Webhook{}, errors.New("url cannot be blank")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["url"] = url
+	params["events"] = events
+	return getWebhook(a, params, webhooks_update_endpoint)
+}
+
+// can error with one of the following: Unknown_Webhook, Invalid_Key, ValidationError, GeneralError
+func (a *MandrillAPI) WebhookDelete(id int) (Webhook, error) {
+	if id <= 0 {
+		return Webhook{}, errors.New("id must be >= 0")
+	}
+	var params map[string]interface{} = make(map[string]interface{})
+	params["id"] = id
+	return getWebhook(a, params, webhooks_delete_endpoint)
+}
+
+func getWebhook(a *MandrillAPI, params map[string]interface{}, endpoint string) (Webhook, error) {
+	var response Webhook
+	err := parseMandrillJson(a, endpoint, params, &response)
+	return response, err
+}
+
+type Webhook struct {
+	Id          int      `json:"id"`
+	Url         string   `json:"url"`
+	AuthKey     string   `json:"auth_key"`
+	Events      []string `json:"events"`
+	CreatedAt   APITime  `json:"created_at"`
+	LastSentAt  APITime  `json:"last_sent_at"`
+	BatchesSent int      `json:"batches_sent"`
+	EventsSent  int      `json:"events_sent"`
+	LastError   string   `json:"last_error"`
+}
+
+func (w Webhook) HasAllEvents(events []string) (found bool) {
+	for _, event := range events {
+		found = false
+		for _, hevent := range w.Events {
+			if event == hevent {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return
+		}
+	}
+	return
+}


### PR DESCRIPTION
- Adds API wrapper for Mailchimp.
- Supports adding, removing and checking for existence of emails in mailing lists on Mailchimp.
- Adds the `gochimp` library.
- For building email lists for the marketing team.