### PR TITLE
PubSub - Check for Started Publishers Before Publish

### DIFF
--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -146,6 +146,9 @@ func (g *GooglePubSub) TopicExists(topicName string) (bool, error) {
 
 // Publish publishes the given message to the pubsub.
 func (g *GooglePubSub) Publish(msg *GooglePubSubMsg) error {
+	if !g.PublishersStarted() {
+		return errors.New("publishers not started, can't publish")
+	}
 	g.publishChan <- msg
 	return nil
 }


### PR DESCRIPTION
If there is no check and publishers have not started, it will hang.  This will throw an error if the publishers are not started before a pubsub publish is attempted.