### PR TITLE
CIVIL-1264 - Improved PubSub Subscriber Error Handling

### DIFF
--- a/pkg/pubsub/pubsub_test.go
+++ b/pkg/pubsub/pubsub_test.go
@@ -1,17 +1,15 @@
 // +build integration
 
-package pubsub_test
+package pubsub
 
 import (
 	// "fmt"
 	"testing"
 	"time"
-
-	"github.com/joincivil/go-common/pkg/pubsub"
 )
 
 func TestCreateDeleteTopic(t *testing.T) {
-	ps, err := pubsub.NewGooglePubSub("civil-media")
+	ps, err := NewGooglePubSub("civil-media")
 	if err != nil {
 		t.Fatalf("Should not have failed to create a new pubsub obj: err: %v", err)
 	}
@@ -45,7 +43,7 @@ func TestCreateDeleteTopic(t *testing.T) {
 }
 
 func TestCreateDeleteSubscription(t *testing.T) {
-	ps, err := pubsub.NewGooglePubSub("civil-media")
+	ps, err := NewGooglePubSub("civil-media")
 	if err != nil {
 		t.Fatalf("Should not have failed to create a new pubsub obj: err: %v", err)
 	}
@@ -76,7 +74,7 @@ func TestCreateDeleteSubscription(t *testing.T) {
 }
 
 func TestStartStopPubSubPublishers(t *testing.T) {
-	ps, err := pubsub.NewGooglePubSub("civil-media")
+	ps, err := NewGooglePubSub("civil-media")
 	if err != nil {
 		t.Fatalf("Should not have failed to create a new pubsub obj: err: %v", err)
 	}
@@ -100,7 +98,7 @@ func TestStartStopPubSubPublishers(t *testing.T) {
 }
 
 func TestStartStopPubSubSubscribers(t *testing.T) {
-	ps, err := pubsub.NewGooglePubSub("civil-media")
+	ps, err := NewGooglePubSub("civil-media")
 	if err != nil {
 		t.Fatalf("Should not have failed to create a new pubsub obj: err: %v", err)
 	}
@@ -144,7 +142,7 @@ func TestStartStopPubSubSubscribers(t *testing.T) {
 }
 
 func TestPubSubPublishersPublish(t *testing.T) {
-	ps, err := pubsub.NewGooglePubSub("civil-media")
+	ps, err := NewGooglePubSub("civil-media")
 	if err != nil {
 		t.Fatalf("Should not have failed to create a new pubsub obj: err: %v", err)
 	}
@@ -188,7 +186,7 @@ func TestPubSubPublishersPublish(t *testing.T) {
 
 	go func() {
 		time.Sleep(2 * time.Second)
-		ps.Publish(&pubsub.GooglePubSubMsg{
+		ps.Publish(&GooglePubSubMsg{
 			Topic:   "test-topic",
 			Payload: "payloadvalue",
 		})
@@ -201,6 +199,86 @@ func TestPubSubPublishersPublish(t *testing.T) {
 
 	if numResults == 0 {
 		t.Errorf("Should have received a messages from pub sub")
+	}
+
+	err = ps.StopPublishers()
+	if err != nil {
+		t.Fatalf("Should have stopped publishers: err: %v", err)
+	}
+	err = ps.StopSubscribers()
+	if err != nil {
+		t.Fatalf("Should have stopped publishers: err: %v", err)
+	}
+	err = ps.DeleteSubscription("test-subscription")
+	if err != nil {
+		t.Errorf("Should have deleted the subscription")
+	}
+	err = ps.DeleteTopic("test-topic")
+	if err != nil {
+		t.Errorf("Should have deleted the test-topic")
+	}
+}
+
+func TestPubSubSubscriberRetry(t *testing.T) {
+	ps, err := NewGooglePubSub("civil-media")
+	if err != nil {
+		t.Fatalf("Should not have failed to create a new pubsub obj: err: %v", err)
+	}
+
+	err = ps.CreateTopic("test-topic")
+	if err != nil {
+		t.Errorf("Should have created a topic")
+	}
+	err = ps.CreateSubscription("test-topic", "test-subscription")
+	if err != nil {
+		t.Errorf("Should not prevented the creation of a the same subscription")
+	}
+
+	// Enable the test path
+	ps.subscribeTestRetry = true
+	err = ps.StartSubscribers("test-subscription")
+	if err != nil {
+		t.Fatalf("Should have started up subscription: err: %v", err)
+	}
+	err = ps.StartPublishers()
+	if err != nil {
+		t.Fatalf("Should have started publishers up: err: %v", err)
+	}
+	time.Sleep(2 * time.Second)
+
+	pubStarted := ps.PublishersStarted()
+	if !pubStarted {
+		t.Fatalf("Should have started publishers")
+	}
+	numPubs := ps.NumPublishersRunning()
+	if numPubs <= 0 {
+		t.Fatalf("Should have started 1 publisher")
+	}
+
+	resultChan := make(chan bool)
+	errorChan := make(chan bool)
+
+	go func() {
+		select {
+		case <-ps.SubscribeChan:
+			resultChan <- true
+		case <-ps.SubscribeErrChan:
+			errorChan <- true
+		}
+	}()
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		ps.Publish(&GooglePubSubMsg{
+			Topic:   "test-topic",
+			Payload: "payloadvalue",
+		})
+	}()
+
+	select {
+	case <-resultChan:
+		t.Errorf("Should not have received a successful message")
+	case <-errorChan:
 	}
 
 	err = ps.StopPublishers()


### PR DESCRIPTION
If pubsub subscribers fail or receive an error, the error would be logged and the worker would exit without a signal that an error occurred or an attempt to retry.  This PR adds both connection retry to the subscribers and also sends an error to an error channel that can be picked up by the caller.

In order to test the retry, added a test field to the struct to activate the retry mechanism for testing, since we use the pubsub simulator for all other tests.  This field is private to the package to prevent accidental usage, which is why the package for `pubsub_test.go` was changed.