### PR TITLE
Signal channels as struct{}, not bool

### DIFF
--- a/pkg/eth/tx_listener.go
+++ b/pkg/eth/tx_listener.go
@@ -31,7 +31,7 @@ const (
 type waiter struct {
 	Mutex       *sync.Mutex
 	DoneWaiting bool
-	QuitChan    chan bool
+	QuitChan    chan struct{}
 }
 
 // TxListener provides methods to interact with Ethereum transactions
@@ -84,7 +84,7 @@ func (t *TxListener) PollForTxCompletion(txID string, updates chan<- string) {
 	w := &waiter{
 		Mutex:       &sync.Mutex{},
 		DoneWaiting: false,
-		QuitChan:    make(chan bool),
+		QuitChan:    make(chan struct{}),
 	}
 	go t.waitForTimeout(w)
 	defer close(w.QuitChan)

--- a/pkg/eth/utils.go
+++ b/pkg/eth/utils.go
@@ -23,7 +23,7 @@ import (
 // NOTE(PN): Need to ensure the client passed in is a websocket client.
 // XXX(PN): I'm not sure of it's effectiveness since all nodes may be configured
 // differently in regards to keeping connections open.
-func WebsocketPing(client *ethclient.Client, killChan <-chan bool, pingIntervalSecs int) {
+func WebsocketPing(client *ethclient.Client, killChan <-chan struct{}, pingIntervalSecs int) {
 	log.Infof("Starting ws ping at %v sec intervals...", pingIntervalSecs)
 Loop:
 	for {

--- a/pkg/lock/local_test.go
+++ b/pkg/lock/local_test.go
@@ -36,7 +36,7 @@ func TestLocalDLock(t *testing.T) {
 		}
 	}(key, dlock)
 
-	kill := make(chan bool)
+	kill := make(chan struct{})
 	go func() {
 		select {
 		case <-time.After(5 * time.Second):

--- a/pkg/lock/redis_test.go
+++ b/pkg/lock/redis_test.go
@@ -62,7 +62,7 @@ func TestRedisDLock(t *testing.T) {
 		}
 	}(key, dlock)
 
-	kill := make(chan bool)
+	kill := make(chan struct{})
 	go func() {
 		select {
 		case <-time.After(5 * time.Second):

--- a/pkg/pubsub/worker_test.go
+++ b/pkg/pubsub/worker_test.go
@@ -3,10 +3,10 @@
 package pubsub_test
 
 import (
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
-	"encoding/json"
 
 	"github.com/joincivil/go-common/pkg/pubsub"
 )
@@ -59,7 +59,7 @@ func TestWorkers(t *testing.T) {
 		testHandler1,
 		testHandler2,
 	}
-	quit := make(chan bool)
+	quit := make(chan struct{})
 	config := &pubsub.WorkersConfig{
 		PubSubProjectID:        "civil-media",
 		PubSubTopicName:        "governance-events",
@@ -109,7 +109,7 @@ func TestWorkers(t *testing.T) {
 		t.Fatalf("Should not have given an error on workers creation: err: %v", err)
 	}
 
-	itquit := make(chan bool)
+	itquit := make(chan struct{})
 
 	go func() {
 		workers.Start()
@@ -160,7 +160,7 @@ func TestWorkersRecovery(t *testing.T) {
 		testHandler1,
 		testHandler2,
 	}
-	quit := make(chan bool)
+	quit := make(chan struct{})
 	config := &pubsub.WorkersConfig{
 		PubSubProjectID:        "civil-media",
 		PubSubTopicName:        "governance-events",
@@ -175,7 +175,7 @@ func TestWorkersRecovery(t *testing.T) {
 		t.Fatalf("Should not have given an error on workers creation: err: %v", err)
 	}
 
-	itquit := make(chan bool)
+	itquit := make(chan struct{})
 
 	go func() {
 		workers.Start()


### PR DESCRIPTION
For clarity, discovered that struct{} is less confusing as a chan type to use for signal channels (close(channel)) rather than a bool.  The bool chan could mean either closing or passing a bool down the channel, which can be confusing when the purpose is simply to signal when closed.

Another benefit is that empty struct{} is more memory efficient than bools.