### PR TITLE
Add Back Original Code to Properly Signal Via Channels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,13 @@ defaults: &defaults
     - image: circleci/golang:1.12.7
     - image: circleci/redis:4.0.14-alpine
     # CircleCI PostgreSQL images available at: https://hub.docker.com/r/circleci/postgres/
-    # - image: circleci/postgres:9.4.12-alpine
+    # - image: circleci/postgres:9.6-alpine
     #   environment:
     #     POSTGRES_USER: root
     #     POSTGRES_DB: circle_test
+    # Run the Google Pub Sub emulator
+    - image: kinok/google-pubsub-emulator:latest
+
 jobs:
   build:
     <<: *defaults
@@ -98,10 +101,10 @@ jobs:
       - run:
           name: Run unit tests
           # environment:
-          #    DB_URL: "postgres://root@localhost:5432/circle_test?sslmode=disable"
-          #    DB_MIGRATIONS: /go/src/github.com/joincivil/go-common/migrations
+          #   DB_URL: "postgres://root@localhost:5432/circle_test?sslmode=disable"
+          #   DB_MIGRATIONS: ~/repos/go-common/migrations
           command: |
-            make test
+            make test-integration
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -174,6 +174,16 @@ func (g *GooglePubSub) NumPublishersRunning() int {
 
 // StopPublishers will stop the publisher goroutines
 func (g *GooglePubSub) StopPublishers() error {
+	for {
+		g.publishMutex.Lock()
+		if g.numRunningPublish == 0 {
+			g.publishMutex.Unlock()
+			break
+		}
+		g.publishMutex.Unlock()
+		g.publishKill <- struct{}{}
+		time.Sleep(1 * time.Second)
+	}
 	close(g.publishKill)
 	close(g.publishChan)
 	g.publishStarted = false

--- a/pkg/pubsub/worker.go
+++ b/pkg/pubsub/worker.go
@@ -117,10 +117,10 @@ Loop:
 func (w *Workers) runWorker() {
 	go func() {
 		time.Sleep(1 * time.Second)
-		close(w.workerStartChan)
+		w.workerStartChan <- struct{}{}
 		// Blocks here, unless initial failure
 		w.worker()
-		close(w.workerStopChan)
+		w.workerStopChan <- struct{}{}
 	}()
 }
 


### PR DESCRIPTION
**Fixes**

1. In a previous PR, introduced a race condition where closing the kill channel at the same time as closing the publish channel creates a situation where a nil object may get passed if there is still one goroutine running and the publish chan is closed.  This puts back the original code that explicitly kills each pub goroutine. 
2. Killed channels when we should be just passing messages down those channels to track the number of workers.
3. Enables test-integration in CI which should help us catch this issue going forward.  I didn't run the integration tests, just the regular tests last time and the CI didn't catch this.