### PR TITLE
Add Accept Header to Rest Client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,11 +221,11 @@ build: check-go-env ## Builds the repo, mainly to ensure all the files will buil
 
 .PHONY: test
 test: check-go-env ## Runs unit tests and tests code coverage
-	@echo 'mode: atomic' > coverage.txt && $(GOTEST) -covermode=atomic -coverprofile=coverage.txt -v -race -timeout=60s ./...
+	@echo 'mode: atomic' > coverage.txt && $(GOTEST) -covermode=atomic -coverprofile=coverage.txt -v -race -timeout=300s ./...
 
 .PHONY: test-integration
 test-integration: check-go-env ## Runs tagged integration tests
-	@echo 'mode: atomic' > coverage.txt && PUBSUB_EMULATOR_HOST=localhost:8042 $(GOTEST) -covermode=atomic -coverprofile=coverage.txt -v -race -timeout=60s -tags=integration ./...
+	@echo 'mode: atomic' > coverage.txt && PUBSUB_EMULATOR_HOST=localhost:8042 $(GOTEST) -covermode=atomic -coverprofile=coverage.txt -v -race -timeout=300s -tags=integration ./...
 
 .PHONY: cover
 cover: test ## Runs unit tests, code coverage, and runs HTML coverage tool.

--- a/pkg/http/rest.go
+++ b/pkg/http/rest.go
@@ -156,7 +156,9 @@ func (h *RestHelper) buildPostPutRequest(method string, url string,
 		url,
 		reqBody,
 	)
+	// XXX(PN): Make headers configurable, likely send other data besides JSON
 	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "*/*")
 	if err != nil {
 		return nil, err
 	}
@@ -171,6 +173,7 @@ func (h *RestHelper) buildGetDeleteRequest(method string, url string,
 		url,
 		nil,
 	)
+	req.Header.Add("Accept", "*/*")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Found some situations where the server returns errors without the `Accept` header set.  So setting it to `*/*`.  Should ultimately pass in the required headers to this helper client.